### PR TITLE
Remove sa-mp deprecated methods

### DIFF
--- a/src/SampSharp.GameMode/Natives/Native.players.cs
+++ b/src/SampSharp.GameMode/Natives/Native.players.cs
@@ -1408,19 +1408,6 @@ namespace SampSharp.GameMode.Natives
         public static extern bool RemovePlayerMapIcon(int playerid, int iconid);
 
         /// <summary>
-        ///     Enable/Disable the teleporting ability for a player by right-clicking on the map.
-        /// </summary>
-        /// <remarks>
-        ///     This function will work only if <see cref="AllowAdminTeleport" /> is working, and you have to be an admin.
-        /// </remarks>
-        /// <param name="playerid">playerid</param>
-        /// <param name="allow">True-allow, False-disallow</param>
-        /// <returns>This function doesn't return a specific value.</returns>
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [Obsolete("This function is deprecated. Use the OnPlayerClickMap callback instead.")]
-        public static extern bool AllowPlayerTeleport(int playerid, bool allow);
-
-        /// <summary>
         ///     Sets the camera to a specific position for a player.
         /// </summary>
         /// <param name="playerid">ID of the player.</param>

--- a/src/SampSharp.GameMode/Natives/Native.samp.cs
+++ b/src/SampSharp.GameMode/Natives/Native.samp.cs
@@ -348,27 +348,6 @@ namespace SampSharp.GameMode.Natives
         public static extern bool SetGravity(float gravity);
 
         /// <summary>
-        ///     This function will determine whether RCON admins will be teleported to their waypoint when they set one.
-        /// </summary>
-        /// <param name="allow">False to disable and True to enable.</param>
-        /// <returns>This function doesn't return a specific value.</returns>
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [Obsolete("This function is deprecated. Use the OnPlayerClickMap callback instead.")]
-        public static extern bool AllowAdminTeleport(bool allow);
-
-        /// <summary>
-        ///     Set the amount of money dropped when a player dies.
-        /// </summary>
-        /// <remarks>
-        ///     This function does not work in the current SA:MP version.
-        /// </remarks>
-        /// <param name="amount">Tthe amount of money dropped when a player dies.</param>
-        /// <returns>This function doesn't return a specific value.</returns>
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [Obsolete("This function is deprecated. Use the OnPlayerDeath callback and CreatePickup method instead.")]
-        public static extern bool SetDeathDropAmount(int amount);
-
-        /// <summary>
         ///     Create an explosion at the specified coordinates.
         /// </summary>
         /// <param name="x">The X coordinate of the explosion.</param>
@@ -379,17 +358,6 @@ namespace SampSharp.GameMode.Natives
         /// <returns>This function doesn't return a specific value.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool CreateExplosion(float x, float y, float z, int type, float radius);
-
-        /// <summary>
-        ///     This function allows to turn on zone / area names such as the "Vinewood" or "Doherty" text at the bottom-right of
-        ///     the screen as they enter the area. This is a gamemode option and should be set in the callback
-        ///     <see cref="BaseMode.OnInitialized" />.
-        /// </summary>
-        /// <param name="enable">A toggle option for whether or not you'd like zone names on or off. False is off and True is on.</param>
-        /// <returns>This function doesn't return a specific value.</returns>
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [Obsolete("This function is deprecated. You must create your own textdraws to show zone names.")]
-        public static extern bool EnableZoneNames(bool enable);
 
         /// <summary>
         ///     Uses standard player walking animation (animation of CJ) instead of custom animations for every skin (e.g. skating

--- a/src/SampSharp/natives.h
+++ b/src/SampSharp/natives.h
@@ -967,7 +967,6 @@ void LoadNatives()
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::ShowPlayerNameTagForPlayer", (void *)sampgdk_ShowPlayerNameTagForPlayer);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetPlayerMapIcon", (void *)sampgdk_SetPlayerMapIcon);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::RemovePlayerMapIcon", (void *)sampgdk_RemovePlayerMapIcon);
-	mono_add_internal_call("SampSharp.GameMode.Natives.Native::AllowPlayerTeleport", (void *)sampgdk_AllowPlayerTeleport);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetPlayerCameraPos", (void *)sampgdk_SetPlayerCameraPos);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetPlayerCameraLookAt", (void *)sampgdk_SetPlayerCameraLookAt);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetCameraBehindPlayer", (void *)sampgdk_SetCameraBehindPlayer);
@@ -1019,15 +1018,11 @@ void LoadNatives()
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::GameModeExit", (void *)sampgdk_GameModeExit);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetWorldTime", (void *)sampgdk_SetWorldTime);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::GetWeaponName", (void *)p_GetWeaponName);
-	mono_add_internal_call("SampSharp.GameMode.Natives.Native::EnableTirePopping", (void *)sampgdk_EnableTirePopping);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::EnableVehicleFriendlyFire", (void *)sampgdk_EnableVehicleFriendlyFire);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::AllowInteriorWeapons", (void *)sampgdk_AllowInteriorWeapons);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetWeather", (void *)sampgdk_SetWeather);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetGravity", (void *)sampgdk_SetGravity);
-	mono_add_internal_call("SampSharp.GameMode.Natives.Native::AllowAdminTeleport", (void *)sampgdk_AllowAdminTeleport);
-	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetDeathDropAmount", (void *)sampgdk_SetDeathDropAmount);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::CreateExplosion", (void *)sampgdk_CreateExplosion);
-	mono_add_internal_call("SampSharp.GameMode.Natives.Native::EnableZoneNames", (void *)sampgdk_EnableZoneNames);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::UsePlayerPedAnims", (void *)sampgdk_UsePlayerPedAnims);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::DisableInteriorEnterExits", (void *)sampgdk_DisableInteriorEnterExits);
 	mono_add_internal_call("SampSharp.GameMode.Natives.Native::SetNameTagDrawDistance", (void *)sampgdk_SetNameTagDrawDistance);


### PR DESCRIPTION
I've removed all them (except for Enabletirepopping which doesn't have a C# method) without touching the C++ native code (don't know how it works, so...)

See #102  for the list