### PR TITLE
Add ShowAsync to show the Dialog and wait for the response in an async way

### DIFF
--- a/src/SampSharp.GameMode/Display/Dialog.cs
+++ b/src/SampSharp.GameMode/Display/Dialog.cs
@@ -294,13 +294,10 @@ namespace SampSharp.GameMode.Display
 
         public virtual async Task<DialogResponseEventArgs> ShowAsync(GtaPlayer player)
         {
-            if (player == null)
-                throw new ArgumentNullException("player");
+            Show(player);
 
             var taskControl = new TaskCompletionSource<DialogResponseEventArgs>();
             asyncTasksCompletation[player.Id] = taskControl;
-
-            Show(player);
 
             var response = await taskControl.Task;
             return response;

--- a/src/SampSharp.GameMode/Display/Dialog.cs
+++ b/src/SampSharp.GameMode/Display/Dialog.cs
@@ -294,19 +294,12 @@ namespace SampSharp.GameMode.Display
 
         public virtual async Task<DialogResponseEventArgs> ShowAsync(GtaPlayer player)
         {
-            if (player == null)
-                throw new ArgumentNullException("player");
-
             var taskControl = new TaskCompletionSource<DialogResponseEventArgs>();
-
-            OpenDialogs[player.Id] = this;
             asyncTasksCompletation[player.Id] = taskControl;
 
-            Native.ShowPlayerDialog(player.Id, DialogId, (int)Style, Caption, Message, Button1,
-                Button2 ?? string.Empty);
+            Show(player);
 
             var response = await taskControl.Task;
-
             return response;
         }
 

--- a/src/SampSharp.GameMode/Display/Dialog.cs
+++ b/src/SampSharp.GameMode/Display/Dialog.cs
@@ -294,6 +294,9 @@ namespace SampSharp.GameMode.Display
 
         public virtual async Task<DialogResponseEventArgs> ShowAsync(GtaPlayer player)
         {
+            if (player == null)
+                throw new ArgumentNullException("player");
+
             var taskControl = new TaskCompletionSource<DialogResponseEventArgs>();
             asyncTasksCompletation[player.Id] = taskControl;
 

--- a/src/SampSharp.GameMode/Display/Dialog.cs
+++ b/src/SampSharp.GameMode/Display/Dialog.cs
@@ -322,6 +322,14 @@ namespace SampSharp.GameMode.Display
             if (OpenDialogs.ContainsKey(player.Id))
                 OpenDialogs.Remove(player.Id);
 
+            if (asyncTasksCompletation.ContainsKey(player.Id))
+            {
+                var task = asyncTasksCompletation[player.Id];
+
+                task.SetCanceled();
+                asyncTasksCompletation.Remove(player.Id);
+            }
+
             Native.ShowPlayerDialog(player.Id, DialogHideId, (int) DialogStyle.MessageBox, string.Empty,
                 string.Empty, string.Empty, string.Empty);
         }


### PR DESCRIPTION
I've tried with two players (in the same pc with SandBoxie) and everything seems to work OK. 

Usage example

    [Command("askme")]
    public static async void AskMe(GtaPlayer player)
    {
        var dialog = new Dialog(DialogStyle.Input, "Hello", "Insert something", "Confirm", "NO");
        var response = await dialog.ShowAsync(player);

        player.SendClientMessage("Response: " + response.InputText);
    }

It should fix #111 

In the case of Async the Event Response is still fired, but I think we could not invoke it since the programmer will handle the response after the method call.

Let me know if this implementation is OK for you, since i'm mostly a Java programmer I don't know if there is a best way to implement it.