### PR TITLE
Permission check

### DIFF
--- a/src/SampSharp.GameMode/Controllers/CommandController.cs
+++ b/src/SampSharp.GameMode/Controllers/CommandController.cs
@@ -108,7 +108,7 @@ namespace SampSharp.GameMode.Controllers
             List<Tuple<Tuple<int, string>, Command>> candidates = new List<Tuple<Tuple<int, string>, Command>>();
 
             // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (Command cmd in Command.All.Where(c => c.HasPlayerPermissionForCommand(player)))
+            foreach (Command cmd in Command.All)
             {
                 string args = text;
                 int count = cmd.CommandTextMatchesCommand(ref args);

--- a/src/SampSharp.GameMode/SAMP/Commands/CommandAttribute.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/CommandAttribute.cs
@@ -57,8 +57,8 @@ namespace SampSharp.GameMode.SAMP.Commands
         public string Shortcut { get; set; }
 
         /// <summary>
-        ///     Gets or sets the method run to check whether a player has the permissions the run the command.
+        ///     Gets or sets the class to run to check whether a player has the permissions the run the command.
         /// </summary>
-        public string PermissionCheckMethod { get; set; }
+        public Type PermissionChecker { get; set; }
     }
 }

--- a/src/SampSharp.GameMode/SAMP/Commands/IPermissionChecker.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/IPermissionChecker.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using SampSharp.GameMode.World;
+
+namespace SampSharp.GameMode.SAMP.Commands
+{
+    /// <summary>
+    ///     A Permission checker is used to check if a player
+    ///     is allowed to use a specific command.
+    /// 
+    ///     Every class that implement this interface
+    ///     should create parameter-less constructor or let
+    ///     the compiler create one
+    /// </summary>
+    public interface IPermissionChecker
+    {
+        /// <summary>
+        ///     The message that the user should see when 
+        ///     he doesn't have the permission to use the command.
+        /// 
+        ///     If null the default SA-MP message will be used.
+        /// </summary>
+        string Message { get; }
+
+        /// <summary>
+        ///     Called when a user tries to use a command
+        ///     that require permission.
+        /// </summary>
+        /// <param name="player">The player that has tried to execute the command</param>
+        /// <returns>Return true if the player passed as argument is allowed to use the command, False otherwise.</returns>
+        bool Check(GtaPlayer player);
+    }
+}

--- a/src/SampSharp.GameMode/SAMP/Commands/IPermissionChecker.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/IPermissionChecker.cs
@@ -8,7 +8,7 @@ namespace SampSharp.GameMode.SAMP.Commands
     ///     is allowed to use a specific command.
     /// 
     ///     Every class that implement this interface
-    ///     should create parameter-less constructor or let
+    ///     should have a parameter-less constructor or let
     ///     the compiler create one
     /// </summary>
     public interface IPermissionChecker

--- a/src/SampSharp.GameMode/SampSharp.GameMode.csproj
+++ b/src/SampSharp.GameMode/SampSharp.GameMode.csproj
@@ -108,6 +108,7 @@
     <Compile Include="SAMP\Commands\Command.cs" />
     <Compile Include="SAMP\Commands\EnumAttribute.cs" />
     <Compile Include="SAMP\Commands\FloatAttribute.cs" />
+    <Compile Include="SAMP\Commands\IPermissionChecker.cs" />
     <Compile Include="SAMP\Commands\PlayerAttribute.cs" />
     <Compile Include="SAMP\Delay.cs" />
     <Compile Include="SAMP\KeyChangeHandlerSet.cs" />

--- a/src/TestMode/Checkers/AdminChecker.cs
+++ b/src/TestMode/Checkers/AdminChecker.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SampSharp.GameMode.SAMP.Commands;
+using SampSharp.GameMode.World;
+
+namespace TestMode.Checkers
+{
+    class AdminChecker : IPermissionChecker
+    {
+        public string Message { get; private set; }
+
+        public AdminChecker()
+        {
+            Message = "You must be admin to use this command!";
+        }
+
+        public bool Check(GtaPlayer player)
+        {
+            return player.IsAdmin;
+        }
+    }
+}

--- a/src/TestMode/Checkers/AdminWithoutMessageChecker.cs
+++ b/src/TestMode/Checkers/AdminWithoutMessageChecker.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SampSharp.GameMode.SAMP.Commands;
+using SampSharp.GameMode.World;
+
+namespace TestMode.Checkers
+{
+    class AdminWithoutMessageChecker : IPermissionChecker
+    {
+        public string Message { get; private set; }
+
+        public bool Check(GtaPlayer player)
+        {
+            return player.IsAdmin;
+        }
+    }
+}

--- a/src/TestMode/TestMode.csproj
+++ b/src/TestMode/TestMode.csproj
@@ -39,6 +39,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Checkers\AdminChecker.cs" />
+    <Compile Include="Checkers\AdminWithoutMessageChecker.cs" />
     <Compile Include="GameMode.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestServices.cs" />

--- a/src/TestMode/Tests/CommandsTest.cs
+++ b/src/TestMode/Tests/CommandsTest.cs
@@ -21,6 +21,7 @@ using SampSharp.GameMode.Definitions;
 using SampSharp.GameMode.SAMP;
 using SampSharp.GameMode.SAMP.Commands;
 using SampSharp.GameMode.World;
+using TestMode.Checkers;
 
 namespace TestMode.Tests
 {
@@ -49,7 +50,7 @@ namespace TestMode.Tests
 
         #endregion
 
-        [Command("console", Alias = "c", Shortcut = "1", PermissionCheckMethod = "TestCommandPermission")]
+        [Command("console", Alias = "c", Shortcut = "1", PermissionChecker = typeof(AdminChecker))]
         [CommandGroup("tools")]
         [Text("text")]
         public static void TestCommand(GtaPlayer player, string word, int num, string text)
@@ -61,10 +62,18 @@ namespace TestMode.Tests
             player.SendClientMessage(Color.Green, "Formattest {0} -- {1} ,, {2}", 123, "xyz", "::DD");
         }
 
-        public static bool TestCommandPermission(GtaPlayer player)
+        [Command("adminwomessage", PermissionChecker = typeof(AdminWithoutMessageChecker))]
+        public static void TestAdminOnlyCommandWithoutMessage(GtaPlayer player)
         {
-            return player.IsAdmin;
+            player.SendClientMessage("You are admin, congratz.");
         }
+
+        //[Command("wrongcommandshouldnotcompile", PermissionChecker = typeof(GtaPlayer))]
+        //public static void TestCommandWithAWrongPermissionChecker(GtaPlayer player)
+        //{
+        //    // This method should throw let the commands loading fail
+        //    player.SendClientMessage("wtf?");
+        //}
 
         [Command("list", Alias = "l")]
         [CommandGroup("vehicle")]


### PR DESCRIPTION
It should fix #123

Instead of calling a method now the Framework will create an instance of the class passed in PermissionChecker in the CommandAttribute, and invoke Check method passing the player that has tried to execute the command. 

The property Message is used if a custom message is needed. If null I return "false" when the command is executed so the default message is shown.