### PR TITLE
Changed the virtualworld in the TextLabel constructor to 0

### DIFF
--- a/src/SampSharp.GameMode/World/TextLabel.cs
+++ b/src/SampSharp.GameMode/World/TextLabel.cs
@@ -180,7 +180,7 @@ namespace SampSharp.GameMode.World
         /// <param name="position">The position.</param>
         /// <param name="drawDistance">The draw distance.</param>
         public TextLabel(string text, Color color, Vector3 position, float drawDistance)
-            : this(text, color, position, drawDistance, -1, true)
+            : this(text, color, position, drawDistance, 0, true)
         {
         }
 


### PR DESCRIPTION
If the virtualworld for a textlabel is set to -1 it will no appear in the world, therefore when a label was created using this specific constructor it would not show up in the world.

Reference: https://wiki.sa-mp.com/wiki/Create3DTextLabel