### PR TITLE
Change the way that weapons are handled + MapIcons

### DIFF
--- a/src/SampSharp.GameMode/BaseMode.callbacks.cs
+++ b/src/SampSharp.GameMode/BaseMode.callbacks.cs
@@ -73,7 +73,7 @@ namespace SampSharp.GameMode
         {
             OnPlayerDied(BasePlayer.FindOrCreate(playerid),
                 new DeathEventArgs(killerid == BasePlayer.InvalidId ? null : BasePlayer.FindOrCreate(killerid),
-                    (Weapon) reason));
+                    (WeaponType) reason));
 
             return true;
         }
@@ -466,7 +466,7 @@ namespace SampSharp.GameMode
         {
             OnPlayerTakeDamage(BasePlayer.FindOrCreate(playerid),
                 new DamageEventArgs(issuerid == BasePlayer.InvalidId ? null : BasePlayer.FindOrCreate(issuerid),
-                    amount, (Weapon) weaponid, (BodyPart) bodypart));
+                    amount, (WeaponType) weaponid, (BodyPart) bodypart));
 
             return true;
         }
@@ -476,7 +476,7 @@ namespace SampSharp.GameMode
         {
             OnPlayerGiveDamage(BasePlayer.FindOrCreate(playerid),
                 new DamageEventArgs(damagedid == BasePlayer.InvalidId ? null : BasePlayer.FindOrCreate(damagedid),
-                    amount, (Weapon) weaponid, (BodyPart) bodypart));
+                    amount, (WeaponType) weaponid, (BodyPart) bodypart));
 
             return true;
         }
@@ -612,7 +612,7 @@ namespace SampSharp.GameMode
         internal bool OnPlayerWeaponShot(int playerid, int weaponid, int hittype, int hitid, float fX, float fY,
             float fZ)
         {
-            var args = new WeaponShotEventArgs((Weapon) weaponid, (BulletHitType) hittype, hitid,
+            var args = new WeaponShotEventArgs((WeaponType) weaponid, (BulletHitType) hittype, hitid,
                 new Vector3(fX, fY, fZ));
 
             OnPlayerWeaponShot(BasePlayer.FindOrCreate(playerid), args);
@@ -675,7 +675,7 @@ namespace SampSharp.GameMode
             if (actor == null)
                 return true;
 
-            OnPlayerGiveDamageActor(actor, new DamageEventArgs(BasePlayer.FindOrCreate(playerid), amount, (Weapon) weaponid, (BodyPart) bodypart));
+            OnPlayerGiveDamageActor(actor, new DamageEventArgs(BasePlayer.FindOrCreate(playerid), amount, (WeaponType) weaponid, (BodyPart) bodypart));
 
             return true;
         }

--- a/src/SampSharp.GameMode/BaseMode.events.cs
+++ b/src/SampSharp.GameMode/BaseMode.events.cs
@@ -12,11 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
 using SampSharp.GameMode.Definitions;
 using SampSharp.GameMode.Display;
 using SampSharp.GameMode.Events;
 using SampSharp.GameMode.World;
+using System;
 
 namespace SampSharp.GameMode
 {
@@ -81,7 +81,7 @@ namespace SampSharp.GameMode
         /// </summary>
         /// <remarks>
         ///     This callback will also be called when a vehicle enters water, but the vehicle can be saved from destruction by
-        ///     teleportation or driving out (if only partially submerged). The callback won't be called a second time, and the
+        ///     teleporting or driving out (if only partially submerged). The callback won't be called a second time, and the
         ///     vehicle may disappear when the driver exits, or after a short time.
         /// </remarks>
         public event EventHandler<PlayerEventArgs> VehicleDied;
@@ -205,7 +205,7 @@ namespace SampSharp.GameMode
 
         /// <summary>
         ///     Occurs when the <see cref="OnVehiclePaintjobApplied" /> callback is being called.
-        ///     Called when a player changes the paintjob of their vehicle (in a modshop).
+        ///     Called when a player changes the paintjob of their vehicle (in a mod shop).
         /// </summary>
         public event EventHandler<VehiclePaintjobEventArgs> VehiclePaintjobApplied;
 
@@ -215,7 +215,7 @@ namespace SampSharp.GameMode
         ///     vehicle's colors were changed, and is NEVER called for pay 'n' spray garages.
         /// </summary>
         /// <remarks>
-        ///     Misleadingly, this callback is not called for pay 'n' spray (only modshops).
+        ///     Misleadingly, this callback is not called for pay 'n' spray (only mod shops).
         /// </remarks>
         public event EventHandler<VehicleResprayedEventArgs> VehicleResprayed;
 
@@ -230,7 +230,7 @@ namespace SampSharp.GameMode
 
         /// <summary>
         ///     Occurs when the <see cref="OnUnoccupiedVehicleUpdated" /> callback is being called.
-        ///     This callback is called everytime an unoccupied vehicle updates the server with their status.
+        ///     This callback is called every time an unoccupied vehicle updates the server with their status.
         /// </summary>
         /// <remarks>
         ///     This callback is called very frequently per second per unoccupied vehicle. You should refrain from implementing
@@ -268,7 +268,7 @@ namespace SampSharp.GameMode
 
         /// <summary>
         ///     Occurs when the <see cref="OnRconLoginAttempt(RconLoginAttemptEventArgs)" /> callback is being called.
-        ///     This callback is called when someone tries to login to RCON, succesful or not.
+        ///     This callback is called when someone tries to login to RCON, successful or not.
         /// </summary>
         /// <remarks>
         ///     This callback is only called when /rcon login is used.
@@ -277,7 +277,7 @@ namespace SampSharp.GameMode
 
         /// <summary>
         ///     Occurs when the <see cref="OnPlayerUpdate(BasePlayer,PlayerUpdateEventArgs)" /> callback is being called.
-        ///     This callback is called everytime a client/player updates the server with their status.
+        ///     This callback is called every time a client/player updates the server with their status.
         /// </summary>
         /// <remarks>
         ///     This callback is called very frequently per second per player, only use it when you know what it's meant for.
@@ -347,11 +347,11 @@ namespace SampSharp.GameMode
 
         /// <summary>
         ///     Occurs when the <see cref="OnPlayerClickMap(BasePlayer,PositionEventArgs)" /> callback is being called.
-        ///     This callback is called when a player places a target/waypoint on the pause menu map (by right-clicking).
+        ///     This callback is called when a player places a target / waypoint on the pause menu map (by right-clicking).
         /// </summary>
         /// <remarks>
         ///     The Z value provided is only an estimate; you may find it useful to use a plugin like the MapAndreas plugin to get
-        ///     a more accurate Z coordinate (or for teleportation; use <see cref="BasePlayer.SetPositionFindZ" />).
+        ///     a more accurate Z coordinate (or for teleporting; use <see cref="BasePlayer.SetPositionFindZ" />).
         /// </remarks>
         public event EventHandler<PositionEventArgs> PlayerClickMap;
 
@@ -461,7 +461,7 @@ namespace SampSharp.GameMode
         ///     tick(50 times per second).
         /// </summary>
         public event EventHandler<EventArgs> Tick;
-        
+
         /// <summary>
         ///     Raises the <see cref="Initialized" /> event.
         /// </summary>
@@ -1001,7 +1001,7 @@ namespace SampSharp.GameMode
         /// <summary>
         ///     Raises the <see cref="IncomingConnection" /> event.
         /// </summary>
-        /// <param name="e">An <see cref="ConnectionEventArgs" /> that contains the event dEventArgsata. </param>
+        /// <param name="e">An <see cref="ConnectionEventArgs" /> that contains the event Connection Event Args. </param>
         protected virtual void OnIncomingConnection(ConnectionEventArgs e)
         {
             IncomingConnection?.Invoke(this, e);

--- a/src/SampSharp.GameMode/BaseMode.functions.cs
+++ b/src/SampSharp.GameMode/BaseMode.functions.cs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using SampSharp.GameMode.Definitions;
 using SampSharp.GameMode.SAMP;
 using SampSharp.GameMode.World;
@@ -37,6 +38,7 @@ namespace SampSharp.GameMode
             BaseModeInternal.Instance.DisableNameTagLOS();
         }
 
+
         /// <summary>
         ///     Set the name of the game mode, which appears in the server browser.
         /// </summary>
@@ -54,7 +56,7 @@ namespace SampSharp.GameMode
         /// <param name="mode">The mode you want to use.</param>
         public virtual void ShowPlayerMarkers(PlayerMarkersMode mode)
         {
-            BaseModeInternal.Instance.ShowPlayerMarkers((int) mode);
+            BaseModeInternal.Instance.ShowPlayerMarkers((int)mode);
         }
 
         /// <summary>
@@ -120,147 +122,152 @@ namespace SampSharp.GameMode
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the spawn point of this class.</param>
         /// <param name="zAngle">The direction in which the player should face after spawning.</param>
-        /// <param name="weapon1">The first spawn-weapon for the player.</param>
-        /// <param name="weapon1Ammo">The amount of ammunition for the primary spawn weapon.</param>
-        /// <param name="weapon2">The second spawn-weapon for the player.</param>
-        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weapon.</param>
-        /// <param name="weapon3">The third spawn-weapon for the player.</param>
-        /// <param name="weapon3Ammo">The amount of ammunition for the third spawn weapon.</param>
+        /// <param name="weapon1">The first spawn-weaponType for the player.</param>
+        /// <param name="weapon1Ammo">The amount of ammunition for the primary spawn weaponType.</param>
+        /// <param name="weapon2">The second spawn-weaponType for the player.</param>
+        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weaponType.</param>
+        /// <param name="weapon3">The third spawn-weaponType for the player.</param>
+        /// <param name="weapon3Ammo">The amount of ammunition for the third spawn weaponType.</param>
         /// <returns>
         ///     The ID of the class which was just added. 300 if the class limit (300) was reached. The highest possible class
         ///     ID is 299.
         /// </returns>
-        public virtual int AddPlayerClass(int modelid, Vector3 position, float zAngle, Weapon weapon1, int weapon1Ammo,
-            Weapon weapon2, int weapon2Ammo, Weapon weapon3, int weapon3Ammo)
+        public virtual int AddPlayerClass(int modelId, Vector3 position, float zAngle,
+            WeaponType weapon1, int weapon1Ammo,
+            WeaponType weapon2, int weapon2Ammo,
+            WeaponType weapon3, int weapon3Ammo)
         {
-            return BaseModeInternal.Instance.AddPlayerClass(modelid, position.X, position.Y, position.Z, zAngle, (int) weapon1,
+            return BaseModeInternal.Instance.AddPlayerClass(modelId, position.X, position.Y, position.Z, zAngle, (int)weapon1,
                 weapon1Ammo,
-                (int) weapon2, weapon2Ammo, (int) weapon3, weapon3Ammo);
+                (int)weapon2, weapon2Ammo, (int)weapon3, weapon3Ammo);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the spawn point of this class.</param>
         /// <param name="zAngle">The direction in which the player should face after spawning.</param>
-        /// <param name="weapon1">The first spawn-weapon for the player.</param>
-        /// <param name="weapon1Ammo">The amount of ammunition for the primary spawn weapon.</param>
-        /// <param name="weapon2">The second spawn-weapon for the player.</param>
-        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weapon.</param>
+        /// <param name="weapon1">The first spawn-weaponType for the player.</param>
+        /// <param name="weapon1Ammo">The amount of ammunition for the primary spawn weaponType.</param>
+        /// <param name="weapon2">The second spawn-weaponType for the player.</param>
+        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weaponType.</param>
         /// <returns>
         ///     The ID of the class which was just added. 300 if the class limit (300) was reached. The highest possible class
         ///     ID is 299.
         /// </returns>
-        public virtual int AddPlayerClass(int modelid, Vector3 position, float zAngle, Weapon weapon1, int weapon1Ammo,
-            Weapon weapon2, int weapon2Ammo)
+        public virtual int AddPlayerClass(int modelId, Vector3 position, float zAngle,
+            WeaponType weapon1, int weapon1Ammo,
+            WeaponType weapon2, int weapon2Ammo)
         {
-            return AddPlayerClass(modelid, position, zAngle, weapon1, weapon1Ammo, weapon2, weapon2Ammo, Weapon.None, 0);
+            return AddPlayerClass(modelId, position, zAngle, weapon1, weapon1Ammo, weapon2, weapon2Ammo, WeaponType.None, 0);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the spawn point of this class.</param>
         /// <param name="zAngle">The direction in which the player should face after spawning.</param>
-        /// <param name="weapon">The spawn-weapon for the player.</param>
-        /// <param name="weaponAmmo">The amount of ammunition for the spawn weapon.</param>
+        /// <param name="weaponType">The spawn-weaponType for the player.</param>
+        /// <param name="weaponAmmo">The amount of ammunition for the spawn weaponType.</param>
         /// <returns>
         ///     The ID of the class which was just added. 300 if the class limit (300) was reached. The highest possible class
         ///     ID is 299.
         /// </returns>
-        public virtual int AddPlayerClass(int modelid, Vector3 position, float zAngle, Weapon weapon, int weaponAmmo)
+        public virtual int AddPlayerClass(int modelId, Vector3 position, float zAngle, WeaponType weaponType, int weaponAmmo)
         {
-            return AddPlayerClass(modelid, position, zAngle, weapon, weaponAmmo, Weapon.None, 0, Weapon.None, 0);
+            return AddPlayerClass(modelId, position, zAngle, weaponType, weaponAmmo, WeaponType.None, 0, WeaponType.None, 0);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the spawn point of this class.</param>
         /// <param name="zAngle">The direction in which the player should face after spawning.</param>
         /// <returns>
         ///     The ID of the class which was just added. 300 if the class limit (300) was reached. The highest possible class
         ///     ID is 299.
         /// </returns>
-        public virtual int AddPlayerClass(int modelid, Vector3 position, float zAngle)
+        public virtual int AddPlayerClass(int modelId, Vector3 position, float zAngle)
         {
-            return AddPlayerClass(modelid, position, zAngle, Weapon.None, 0, Weapon.None, 0, Weapon.None, 0);
+            return AddPlayerClass(modelId, position, zAngle, WeaponType.None, 0, WeaponType.None, 0, WeaponType.None, 0);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
         /// <param name="teamid">The team you want the player to spawn in.</param>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the class' spawn position.</param>
         /// <param name="zAngle">The direction in which the player will face after spawning.</param>
-        /// <param name="weapon1">The first spawn-weapon for the player.</param>
-        /// <param name="weapon1Ammo">The amount of ammunition for the first spawn weapon.</param>
-        /// <param name="weapon2">The second spawn-weapon for the player.</param>
-        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weapon.</param>
-        /// <param name="weapon3">The third spawn-weapon for the player.</param>
-        /// <param name="weapon3Ammo">The amount of ammunition for the third spawn weapon.</param>
+        /// <param name="weapon1">The first spawn-weaponType for the player.</param>
+        /// <param name="weapon1Ammo">The amount of ammunition for the first spawn weaponType.</param>
+        /// <param name="weapon2">The second spawn-weaponType for the player.</param>
+        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weaponType.</param>
+        /// <param name="weapon3">The third spawn-weaponType for the player.</param>
+        /// <param name="weapon3Ammo">The amount of ammunition for the third spawn weaponType.</param>
         /// <returns>The ID of the class that was just created.</returns>
-        public virtual int AddPlayerClass(int teamid, int modelid, Vector3 position, float zAngle, Weapon weapon1,
-            int weapon1Ammo, Weapon weapon2, int weapon2Ammo, Weapon weapon3, int weapon3Ammo)
+        public virtual int AddPlayerClass(int teamid, int modelId, Vector3 position, float zAngle,
+            WeaponType weapon1, int weapon1Ammo,
+            WeaponType weapon2, int weapon2Ammo,
+            WeaponType weapon3, int weapon3Ammo)
         {
-            return BaseModeInternal.Instance.AddPlayerClassEx(teamid, modelid, position.X, position.Y, position.Z, zAngle,
-                (int) weapon1,
-                weapon1Ammo, (int) weapon2, weapon2Ammo, (int) weapon3, weapon3Ammo);
+            return BaseModeInternal.Instance.AddPlayerClassEx(teamid, modelId, position.X, position.Y, position.Z, zAngle,
+                (int)weapon1,
+                weapon1Ammo, (int)weapon2, weapon2Ammo, (int)weapon3, weapon3Ammo);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
         /// <param name="teamid">The team you want the player to spawn in.</param>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the class' spawn position.</param>
         /// <param name="zAngle">The direction in which the player will face after spawning.</param>
-        /// <param name="weapon1">The first spawn-weapon for the player.</param>
-        /// <param name="weapon1Ammo">The amount of ammunition for the first spawn weapon.</param>
-        /// <param name="weapon2">The second spawn-weapon for the player.</param>
-        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weapon.</param>
+        /// <param name="weapon1">The first spawn-weaponType for the player.</param>
+        /// <param name="weapon1Ammo">The amount of ammunition for the first spawn weaponType.</param>
+        /// <param name="weapon2">The second spawn-weaponType for the player.</param>
+        /// <param name="weapon2Ammo">The amount of ammunition for the second spawn weaponType.</param>
         /// <returns>The ID of the class that was just created.</returns>
-        public virtual int AddPlayerClass(int teamid, int modelid, Vector3 position, float zAngle, Weapon weapon1,
-            int weapon1Ammo, Weapon weapon2, int weapon2Ammo)
+        public virtual int AddPlayerClass(int teamid, int modelId, Vector3 position, float zAngle,
+            WeaponType weapon1, int weapon1Ammo,
+            WeaponType weapon2, int weapon2Ammo)
         {
-            return AddPlayerClass(teamid, modelid, position, zAngle, weapon1, weapon1Ammo, weapon2, weapon2Ammo,
-                Weapon.None, 0);
+            return AddPlayerClass(teamid, modelId, position, zAngle, weapon1, weapon1Ammo, weapon2, weapon2Ammo,
+                WeaponType.None, 0);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
         /// <param name="teamid">The team you want the player to spawn in.</param>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the class' spawn position.</param>
         /// <param name="zAngle">The direction in which the player will face after spawning.</param>
-        /// <param name="weapon">The spawn-weapon for the player.</param>
-        /// <param name="weaponAmmo">The amount of ammunition for the spawn weapon.</param>
+        /// <param name="weaponType">The spawn-weaponType for the player.</param>
+        /// <param name="weaponAmmo">The amount of ammunition for the spawn weaponType.</param>
         /// <returns>The ID of the class that was just created.</returns>
-        public virtual int AddPlayerClass(int teamid, int modelid, Vector3 position, float zAngle, Weapon weapon,
-            int weaponAmmo)
+        public virtual int AddPlayerClass(int teamid, int modelId, Vector3 position, float zAngle, WeaponType weaponType, int weaponAmmo)
         {
-            return AddPlayerClass(teamid, modelid, position, zAngle, weapon, weaponAmmo, Weapon.None, 0, Weapon.None, 0);
+            return AddPlayerClass(teamid, modelId, position, zAngle, weaponType, weaponAmmo, WeaponType.None, 0, WeaponType.None, 0);
         }
 
         /// <summary>
         ///     Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.
         /// </summary>
         /// <param name="teamid">The team you want the player to spawn in.</param>
-        /// <param name="modelid">The skin which the player will spawn with.</param>
+        /// <param name="modelId">The skin which the player will spawn with.</param>
         /// <param name="position">The coordinate of the class' spawn position.</param>
         /// <param name="zAngle">The direction in which the player will face after spawning.</param>
         /// <returns>The ID of the class that was just created.</returns>
-        public virtual int AddPlayerClass(int teamid, int modelid, Vector3 position, float zAngle)
+        public virtual int AddPlayerClass(int teamid, int modelId, Vector3 position, float zAngle)
         {
-            return AddPlayerClass(teamid, modelid, position, zAngle, Weapon.None, 0, Weapon.None, 0, Weapon.None, 0);
+            return AddPlayerClass(teamid, modelId, position, zAngle, WeaponType.None, 0, WeaponType.None, 0, WeaponType.None, 0);
         }
 
         /// <summary>

--- a/src/SampSharp.GameMode/Definitions/WeaponType.cs
+++ b/src/SampSharp.GameMode/Definitions/WeaponType.cs
@@ -17,7 +17,7 @@ namespace SampSharp.GameMode.Definitions
     /// <summary>
     ///     Contains all weapons.
     /// </summary>
-    public enum Weapon
+    public enum WeaponType
     {
         /// <summary>
         ///     No weapon.

--- a/src/SampSharp.GameMode/Events/DamageEventArgs.cs
+++ b/src/SampSharp.GameMode/Events/DamageEventArgs.cs
@@ -29,13 +29,13 @@ namespace SampSharp.GameMode.Events
         /// </summary>
         /// <param name="otherPlayer">The other player.</param>
         /// <param name="amount">Amount of damage done.</param>
-        /// <param name="weapon">Weapon used to damage another.</param>
+        /// <param name="weaponType">Weapon used to damage another.</param>
         /// <param name="bodypart">BodyPart shot at.</param>
-        public DamageEventArgs(BasePlayer otherPlayer, float amount, Weapon weapon, BodyPart bodypart)
+        public DamageEventArgs(BasePlayer otherPlayer, float amount, WeaponType weaponType, BodyPart bodypart)
         {
             OtherPlayer = otherPlayer;
             Amount = amount;
-            Weapon = weapon;
+            WeaponType = weaponType;
             BodyPart = bodypart;
         }
 
@@ -52,7 +52,7 @@ namespace SampSharp.GameMode.Events
         /// <summary>
         ///     Gets the Weapon used to damage another player.
         /// </summary>
-        public Weapon Weapon { get; private set; }
+        public WeaponType WeaponType { get; private set; }
 
         /// <summary>
         ///     Gets the BodyPart shot at.

--- a/src/SampSharp.GameMode/Events/DeathEventArgs.cs
+++ b/src/SampSharp.GameMode/Events/DeathEventArgs.cs
@@ -28,7 +28,7 @@ namespace SampSharp.GameMode.Events
         /// </summary>
         /// <param name="killer">The killer.</param>
         /// <param name="reason">Reason of the death.</param>
-        public DeathEventArgs(BasePlayer killer, Weapon reason)
+        public DeathEventArgs(BasePlayer killer, WeaponType reason)
         {
             Killer = killer;
             DeathReason = reason;
@@ -42,6 +42,6 @@ namespace SampSharp.GameMode.Events
         /// <summary>
         ///     Gets the reason of the death.
         /// </summary>
-        public Weapon DeathReason { get; private set; }
+        public WeaponType DeathReason { get; private set; }
     }
 }

--- a/src/SampSharp.GameMode/Events/WeaponShotEventArgs.cs
+++ b/src/SampSharp.GameMode/Events/WeaponShotEventArgs.cs
@@ -25,22 +25,22 @@ namespace SampSharp.GameMode.Events
         /// <summary>
         ///     Initializes a new instance of the <see cref="WeaponShotEventArgs" /> class.
         /// </summary>
-        /// <param name="weapon">The weapon.</param>
+        /// <param name="weaponType">The weaponType.</param>
         /// <param name="hittype">The hittype.</param>
         /// <param name="hitid">The hitid.</param>
         /// <param name="position">The position.</param>
-        public WeaponShotEventArgs(Weapon weapon, BulletHitType hittype, int hitid, Vector3 position)
+        public WeaponShotEventArgs(WeaponType weaponType, BulletHitType hittype, int hitid, Vector3 position)
             : base(position)
         {
-            Weapon = weapon;
+            WeaponType = weaponType;
             BulletHitType = hittype;
             HitId = hitid;
         }
 
         /// <summary>
-        ///     Gets the weapon.
+        ///     Gets the weaponType.
         /// </summary>
-        public Weapon Weapon { get; private set; }
+        public WeaponType WeaponType { get; private set; }
 
         /// <summary>
         ///     Gets the type of the bullet hit.

--- a/src/SampSharp.GameMode/World/BaseMapIcon.cs
+++ b/src/SampSharp.GameMode/World/BaseMapIcon.cs
@@ -1,0 +1,75 @@
+﻿using SampSharp.GameMode.Definitions;
+using SampSharp.GameMode.SAMP;
+using static SampSharp.GameMode.World.BasePlayer;
+
+namespace SampSharp.GameMode.World
+{
+    /// <summary>
+    /// Represents a Map Icon.
+    /// </summary>
+    public class BaseMapIcon
+    {
+        /// <summary>
+        /// Where to show the map icon.
+        /// </summary>
+        public Vector3 Position { get; set; }
+
+        /// <summary>
+        /// The type of the icon.
+        /// </summary>
+        public MapIcon Type { get; set; }
+
+        /// <summary>
+        /// The style (global etc.)
+        /// </summary>
+        public MapIconType Style { get; set; }
+
+        /// <summary>
+        /// The color of the icon.
+        /// Used for the dynamic square.
+        /// </summary>
+        public Color Color { get; set; }
+
+        /// <summary>
+        /// The Id assigned by SAMP to the icon.
+        /// </summary>
+        private int _iconId;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="type"></param>
+        /// <param name="style"></param>
+        /// <param name="color"></param>
+        public BaseMapIcon(Vector3 position, MapIcon type, MapIconType style, Color color = default)
+        {
+            Position = position;
+            Type = type;
+            Style = style;
+            Color = color;
+        }
+
+        /// <summary>
+        /// Show the icon to a player.
+        /// </summary>
+        /// <param name="player"></param>
+        public bool Show(BasePlayer player)
+        {
+            player.MapIcons.Add(this);
+            _iconId = player.MapIcons.Count;
+            return PlayerInternal.Instance.SetPlayerMapIcon(player.Id, _iconId, Position.X, Position.Y, Position.Z, (int)Type, (int)Color,
+                (int)Style);
+        }
+
+        /// <summary>
+        /// Hide the icon from the player.
+        /// </summary>
+        /// <param name="player"></param>
+        public void Hide(BasePlayer player)
+        {
+            player.MapIcons.Remove(this);
+            PlayerInternal.Instance.RemovePlayerMapIcon(player.Id, _iconId);
+        }
+    }
+}

--- a/src/SampSharp.GameMode/World/BaseMapIcon.cs
+++ b/src/SampSharp.GameMode/World/BaseMapIcon.cs
@@ -41,8 +41,22 @@ namespace SampSharp.GameMode.World
         /// <param name="position"></param>
         /// <param name="type"></param>
         /// <param name="style"></param>
+        public BaseMapIcon(Vector3 position, MapIcon type, MapIconType style)
+        {
+            Position = position;
+            Type = type;
+            Style = style;
+            Color = Color.Red;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="type"></param>
+        /// <param name="style"></param>
         /// <param name="color"></param>
-        public BaseMapIcon(Vector3 position, MapIcon type, MapIconType style, Color color = default)
+        public BaseMapIcon(Vector3 position, MapIcon type, MapIconType style, Color color)
         {
             Position = position;
             Type = type;

--- a/src/SampSharp.GameMode/World/BasePlayer.cs
+++ b/src/SampSharp.GameMode/World/BasePlayer.cs
@@ -12,16 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
-using System.Linq;
-using System.Xml;
-using SampSharp.GameMode.API;
-using SampSharp.Core.Natives.NativeObjects;
 using SampSharp.GameMode.Definitions;
 using SampSharp.GameMode.Display;
 using SampSharp.GameMode.Events;
 using SampSharp.GameMode.Pools;
 using SampSharp.GameMode.SAMP;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SampSharp.GameMode.World
 {
@@ -59,7 +57,7 @@ namespace SampSharp.GameMode.World
         ///     Maximum length of the text in a chat bubble.
         /// </summary>
         public const int MaxChatBubbleLength = 144;
-        
+
         #region Constructors
 
         /// <summary>
@@ -185,12 +183,17 @@ namespace SampSharp.GameMode.World
         /// <summary>
         ///     Gets the WeaponState of the Weapon this Player is currently holding.
         /// </summary>
-        public virtual WeaponState WeaponState => (WeaponState) PlayerInternal.Instance.GetPlayerWeaponState(Id);
+        public virtual WeaponState WeaponState => (WeaponState)PlayerInternal.Instance.GetPlayerWeaponState(Id);
 
         /// <summary>
         ///     Gets the Weapon this Player is currently holding.
         /// </summary>
-        public virtual Weapon Weapon => (Weapon) PlayerInternal.Instance.GetPlayerWeapon(Id);
+        public virtual Weapon Weapon =>
+            GetWeaponData(
+                Weapon.GetWeaponSlot(
+                    (WeaponType)PlayerInternal.Instance.GetPlayerWeapon(Id)
+                )
+            );
 
         /// <summary>
         ///     Gets the Player this Player is aiming at.
@@ -265,7 +268,7 @@ namespace SampSharp.GameMode.World
         /// <summary>
         ///     Gets the state of this Player.
         /// </summary>
-        public virtual PlayerState State => (PlayerState) PlayerInternal.Instance.GetPlayerState(Id);
+        public virtual PlayerState State => (PlayerState)PlayerInternal.Instance.GetPlayerState(Id);
 
         /// <summary>
         ///     Gets the IP of this Player.
@@ -298,8 +301,8 @@ namespace SampSharp.GameMode.World
         /// </summary>
         public virtual FightStyle FightStyle
         {
-            get => (FightStyle) PlayerInternal.Instance.GetPlayerFightingStyle(Id);
-            set => PlayerInternal.Instance.SetPlayerFightingStyle(Id, (int) value);
+            get => (FightStyle)PlayerInternal.Instance.GetPlayerFightingStyle(Id);
+            set => PlayerInternal.Instance.SetPlayerFightingStyle(Id, (int)value);
         }
 
         /// <summary>
@@ -330,8 +333,8 @@ namespace SampSharp.GameMode.World
         /// </summary>
         public virtual SpecialAction SpecialAction
         {
-            get => (SpecialAction) PlayerInternal.Instance.GetPlayerSpecialAction(Id);
-            set => PlayerInternal.Instance.SetPlayerSpecialAction(Id, (int) value);
+            get => (SpecialAction)PlayerInternal.Instance.GetPlayerSpecialAction(Id);
+            set => PlayerInternal.Instance.SetPlayerSpecialAction(Id, (int)value);
         }
 
         /// <summary>
@@ -362,7 +365,7 @@ namespace SampSharp.GameMode.World
         /// <summary>
         ///     Gets the mode of this Player's camera.
         /// </summary>
-        public virtual CameraMode CameraMode => (CameraMode) PlayerInternal.Instance.GetPlayerCameraMode(Id);
+        public virtual CameraMode CameraMode => (CameraMode)PlayerInternal.Instance.GetPlayerCameraMode(Id);
 
         /// <summary>
         ///     Gets the Actor this Player is aiming at.
@@ -534,7 +537,7 @@ namespace SampSharp.GameMode.World
         ///     Gets a value indicating whether this Player is alive.
         /// </summary>
         public virtual bool IsAlive
-            => !new[] {PlayerState.None, PlayerState.Spectating, PlayerState.Wasted}.Contains(State);
+            => !new[] { PlayerState.None, PlayerState.Spectating, PlayerState.Wasted }.Contains(State);
 
 
         /// <summary>
@@ -919,23 +922,23 @@ namespace SampSharp.GameMode.World
         /// <param name="skin">The skin which the player will spawn with.</param>
         /// <param name="position">The player's spawn position.</param>
         /// <param name="rotation">The direction in which the player needs to be facing after spawning.</param>
-        /// <param name="weapon1">The first spawn-weapon for the player.</param>
+        /// <param name="weapon1">The first spawn-weaponType for the player.</param>
         /// <param name="weapon1Ammo">The amount of ammunition for the primary spawnweapon.</param>
-        /// <param name="weapon2">The second spawn-weapon for the player.</param>
+        /// <param name="weapon2">The second spawn-weaponType for the player.</param>
         /// <param name="weapon2Ammo">The amount of ammunition for the second spawnweapon.</param>
-        /// <param name="weapon3">The third spawn-weapon for the player.</param>
+        /// <param name="weapon3">The third spawn-weaponType for the player.</param>
         /// <param name="weapon3Ammo">The amount of ammunition for the third spawnweapon.</param>
         public virtual void SetSpawnInfo(int team, int skin, Vector3 position, float rotation,
-            Weapon weapon1 = Weapon.None,
-            int weapon1Ammo = 0, Weapon weapon2 = Weapon.None, int weapon2Ammo = 0, Weapon weapon3 = Weapon.None,
-            int weapon3Ammo = 0)
+            WeaponType weapon1 = WeaponType.None, int weapon1Ammo = 0, 
+            WeaponType weapon2 = WeaponType.None, int weapon2Ammo = 0,
+            WeaponType weapon3 = WeaponType.None, int weapon3Ammo = 0)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SetSpawnInfo(Id, team, skin, position.X, position.Y, position.Z, rotation, (int) weapon1,
+            PlayerInternal.Instance.SetSpawnInfo(Id, team, skin, position.X, position.Y, position.Z, rotation, (int)weapon1,
                 weapon1Ammo,
-                (int) weapon2, weapon2Ammo,
-                (int) weapon3, weapon3Ammo);
+                (int)weapon2, weapon2Ammo,
+                (int)weapon3, weapon3Ammo);
         }
 
         /// <summary>
@@ -1011,7 +1014,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (other == null)
+            {
                 throw new ArgumentNullException(nameof(other));
+            }
 
             return PlayerInternal.Instance.IsPlayerStreamedIn(other.Id, Id);
         }
@@ -1019,13 +1024,13 @@ namespace SampSharp.GameMode.World
         /// <summary>
         ///     Set the ammo of this <see cref="BasePlayer" />'s weapon.
         /// </summary>
-        /// <param name="weapon">The weapon to set the ammo of.</param>
+        /// <param name="weaponType">The weaponType to set the ammo of.</param>
         /// <param name="ammo">The amount of ammo to set.</param>
-        public virtual void SetAmmo(Weapon weapon, int ammo)
+        public virtual void SetAmmo(WeaponType weaponType, int ammo)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SetPlayerAmmo(Id, (int) weapon, ammo);
+            PlayerInternal.Instance.SetPlayerAmmo(Id, (int)weaponType, ammo);
         }
 
         /// <summary>
@@ -1037,7 +1042,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.GivePlayerWeapon(Id, (int) weapon, ammo);
+            PlayerInternal.Instance.GivePlayerWeapon(Id, (int)weapon.WeaponId, ammo);
         }
 
 
@@ -1052,28 +1057,41 @@ namespace SampSharp.GameMode.World
         }
 
         /// <summary>
-        ///     Sets the armed weapon of this <see cref="BasePlayer" />.
+        ///     Sets the armed weaponType of this <see cref="BasePlayer" />.
         /// </summary>
-        /// <param name="weapon">The weapon that the player should be armed with.</param>
+        /// <param name="weapon">The weaponType that the player should be armed with.</param>
         public virtual void SetArmedWeapon(Weapon weapon)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SetPlayerArmedWeapon(Id, (int) weapon);
+            PlayerInternal.Instance.SetPlayerArmedWeapon(Id, (int)weapon.WeaponId);
         }
 
         /// <summary>
         ///     Get the <see cref="Weapon" /> and ammo in this <see cref="BasePlayer" />'s weapon slot.
         /// </summary>
         /// <param name="slot">The weapon slot to get data for (0-12).</param>
-        /// <param name="weapon">The variable in which to store the weapon, passed by reference.</param>
-        /// <param name="ammo">The variable in which to store the ammo, passed by reference.</param>
-        public virtual void GetWeaponData(int slot, out Weapon weapon, out int ammo)
+        public virtual Weapon GetWeaponData(int slot)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.GetPlayerWeaponData(Id, slot, out var weaponid, out ammo);
-            weapon = (Weapon) weaponid;
+            PlayerInternal.Instance.GetPlayerWeaponData(Id, slot, out var weaponId, out var ammo);
+            return new Weapon((WeaponType)weaponId, ammo);
+        }
+
+        /// <summary>
+        ///     Get all the the <see cref="Weapon" />s this <see cref="BasePlayer" /> owns.
+        /// </summary>
+        public virtual List<Weapon> GetWeaponData()
+        {
+            AssertNotDisposed();
+            var weaponsList = new List<Weapon>();
+            for (var slot = 0; slot <= 12; ++slot)
+            {
+                PlayerInternal.Instance.GetPlayerWeaponData(Id, slot, out var weaponId, out var ammo);
+                weaponsList.Add(new Weapon((WeaponType)weaponId, ammo));
+            }
+            return weaponsList;
         }
 
         /// <summary>
@@ -1112,7 +1130,7 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             PlayerInternal.Instance.GetPlayerKeys(Id, out var keysDown, out updown, out leftright);
-            keys = (Keys) keysDown;
+            keys = (Keys)keysDown;
         }
 
         /// <summary>
@@ -1182,7 +1200,7 @@ namespace SampSharp.GameMode.World
 
             PlayerInternal.Instance.ForceClassSelection(Id);
         }
-        
+
         /// <summary>
         ///     Display the cursor and allow this <see cref="BasePlayer" /> to select a text draw.
         /// </summary>
@@ -1215,7 +1233,11 @@ namespace SampSharp.GameMode.World
         /// <param name="crime">The crime ID, which will be reported as a 10-code (i.e. 10-16 if 16 was passed as the crimeid).</param>
         public virtual void PlayCrimeReport(BasePlayer suspect, int crime)
         {
-            if (suspect == null) throw new ArgumentNullException(nameof(suspect));
+            if (suspect == null)
+            {
+                throw new ArgumentNullException(nameof(suspect));
+            }
+
             AssertNotDisposed();
 
             PlayerInternal.Instance.PlayCrimeReportForPlayer(Id, suspect.Id, crime);
@@ -1302,14 +1324,14 @@ namespace SampSharp.GameMode.World
         /// </remarks>
         /// <param name="skill">The <see cref="WeaponSkill" /> you want to set the skill of.</param>
         /// <param name="level">
-        ///     The skill level to set for that weapon, ranging from 0 to 999. (A level out of range will max it
+        ///     The skill level to set for that weaponType, ranging from 0 to 999. (A level out of range will max it
         ///     out)
         /// </param>
         public virtual void SetSkillLevel(WeaponSkill skill, int level)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SetPlayerSkillLevel(Id, (int) skill, level);
+            PlayerInternal.Instance.SetPlayerSkillLevel(Id, (int)skill, level);
         }
 
         /// <summary>
@@ -1329,7 +1351,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            return PlayerInternal.Instance.SetPlayerAttachedObject(Id, index, modelid, (int) bone, offset.X, offset.Y, offset.Z,
+            return PlayerInternal.Instance.SetPlayerAttachedObject(Id, index, modelid, (int)bone, offset.X, offset.Y, offset.Z,
                 rotation.X, rotation.Y, rotation.Z, scale.X, scale.Y, scale.Z,
                 materialcolor1.ToInteger(ColorFormat.ARGB), materialcolor2.ToInteger(ColorFormat.ARGB));
         }
@@ -1395,7 +1417,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (vehicle == null)
+            {
                 throw new ArgumentNullException(nameof(vehicle));
+            }
 
             PlayerInternal.Instance.PutPlayerInVehicle(Id, vehicle.Id, seatid);
         }
@@ -1589,7 +1613,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SetPlayerRaceCheckpoint(Id, (int) type, point.X, point.Y, point.Z, nextPosition.X, nextPosition.Y,
+            PlayerInternal.Instance.SetPlayerRaceCheckpoint(Id, (int)type, point.X, point.Y, point.Z, nextPosition.X, nextPosition.Y,
                 nextPosition.Z, size);
         }
 
@@ -1631,7 +1655,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (player == null)
+            {
                 throw new ArgumentNullException(nameof(player));
+            }
 
             PlayerInternal.Instance.SetPlayerMarkerForPlayer(Id, player.Id, color.ToInteger(ColorFormat.RGBA));
         }
@@ -1652,7 +1678,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (player == null)
+            {
                 throw new ArgumentNullException(nameof(player));
+            }
 
             PlayerInternal.Instance.ShowPlayerNameTagForPlayer(Id, player.Id, show);
         }
@@ -1672,7 +1700,7 @@ namespace SampSharp.GameMode.World
         public virtual bool SetMapIcon(int iconid, Vector3 position, MapIcon mapIcon, Color color,
             MapIconType style)
         {
-            return SetMapIcon(iconid, position, (int) mapIcon, color, style);
+            return SetMapIcon(iconid, position, (int)mapIcon, color, style);
         }
 
         /// <summary>
@@ -1693,18 +1721,18 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             return PlayerInternal.Instance.SetPlayerMapIcon(Id, iconid, position.X, position.Y, position.Z, mapIcon, color,
-                (int) style);
+                (int)style);
         }
 
         /// <summary>
         ///     Removes a map icon that was set earlier for this <see cref="BasePlayer" />.
         /// </summary>
-        /// <param name="iconid">The ID of the icon to remove. This is the second parameter of <see cref="SetMapIcon" />.</param>
-        public virtual void RemoveMapIcon(int iconid)
+        /// <param name="iconId">The ID of the icon to remove. This is the second parameter of <see cref="SetMapIcon" />.</param>
+        public virtual void RemoveMapIcon(int iconId)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.RemovePlayerMapIcon(Id, iconid);
+            PlayerInternal.Instance.RemovePlayerMapIcon(Id, iconId);
         }
 
         /// <summary>
@@ -1717,7 +1745,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SetPlayerCameraLookAt(Id, point.X, point.Y, point.Z, (int) cut);
+            PlayerInternal.Instance.SetPlayerCameraLookAt(Id, point.X, point.Y, point.Z, (int)cut);
         }
 
         /// <summary>
@@ -1743,7 +1771,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.InterpolateCameraPos(Id, from.X, from.Y, from.Z, to.X, to.Y, to.Z, time, (int) cut);
+            PlayerInternal.Instance.InterpolateCameraPos(Id, from.X, from.Y, from.Z, to.X, to.Y, to.Z, time, (int)cut);
         }
 
         /// <summary>
@@ -1757,7 +1785,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.InterpolateCameraLookAt(Id, from.X, from.Y, from.Z, to.X, to.Y, to.Z, time, (int) cut);
+            PlayerInternal.Instance.InterpolateCameraLookAt(Id, from.X, from.Y, from.Z, to.X, to.Y, to.Z, time, (int)cut);
         }
 
         /// <summary>
@@ -1811,9 +1839,11 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (targetPlayer == null)
+            {
                 throw new ArgumentNullException(nameof(targetPlayer));
+            }
 
-            PlayerInternal.Instance.PlayerSpectatePlayer(Id, targetPlayer.Id, (int) mode);
+            PlayerInternal.Instance.PlayerSpectatePlayer(Id, targetPlayer.Id, (int)mode);
         }
 
         /// <summary>
@@ -1829,7 +1859,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (targetPlayer == null)
+            {
                 throw new ArgumentNullException(nameof(targetPlayer));
+            }
 
             SpectatePlayer(targetPlayer, SpectateMode.Normal);
         }
@@ -1848,9 +1880,11 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (targetVehicle == null)
+            {
                 throw new ArgumentNullException(nameof(targetVehicle));
+            }
 
-            PlayerInternal.Instance.PlayerSpectateVehicle(Id, targetVehicle.Id, (int) mode);
+            PlayerInternal.Instance.PlayerSpectateVehicle(Id, targetVehicle.Id, (int)mode);
         }
 
         /// <summary>
@@ -1866,7 +1900,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (targetVehicle == null)
+            {
                 throw new ArgumentNullException(nameof(targetVehicle));
+            }
 
             SpectateVehicle(targetVehicle, SpectateMode.Normal);
         }
@@ -1883,7 +1919,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.StartRecordingPlayerData(Id, (int) recordtype, recordname);
+            PlayerInternal.Instance.StartRecordingPlayerData(Id, (int)recordtype, recordname);
         }
 
         /// <summary>
@@ -1913,7 +1949,6 @@ namespace SampSharp.GameMode.World
         #endregion
 
         #region SAMP natives
-
         /// <summary>
         ///     This function sends a message to this <see cref="BasePlayer" /> with a chosen color in the chat. The whole line in
         ///     the chat box will be
@@ -2071,7 +2106,9 @@ namespace SampSharp.GameMode.World
             AssertNotDisposed();
 
             if (receiver == null)
+            {
                 throw new ArgumentNullException(nameof(receiver));
+            }
 
             PlayerInternal.Instance.SendPlayerMessageToPlayer(receiver.Id, Id, message);
         }
@@ -2134,7 +2171,9 @@ namespace SampSharp.GameMode.World
         public static void CreateExplosionForAll(Vector3 position, ExplosionType type, float radius, int interior)
         {
             foreach (var p in All.Where(p => p.Interior == interior))
+            {
                 p.CreateExplosion(position, type, radius);
+            }
         }
 
         /// <summary>
@@ -2149,7 +2188,9 @@ namespace SampSharp.GameMode.World
             int virtualworld)
         {
             foreach (var p in All.Where(p => p.Interior == interior && p.VirtualWorld == virtualworld))
+            {
                 p.CreateExplosion(position, type, radius);
+            }
         }
 
         /// <summary>
@@ -2165,7 +2206,7 @@ namespace SampSharp.GameMode.World
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.CreateExplosionForPlayer(Id, position.X, position.Y, position.Z, (int) type, radius);
+            PlayerInternal.Instance.CreateExplosionForPlayer(Id, position.X, position.Y, position.Z, (int)type, radius);
         }
 
         /// <summary>
@@ -2173,12 +2214,12 @@ namespace SampSharp.GameMode.World
         /// </summary>
         /// <param name="killer">The <see cref="BasePlayer" /> that killer the <paramref name="killee" />.</param>
         /// <param name="killee">The <see cref="BasePlayer" /> that has been killed.</param>
-        /// <param name="weapon">The reason for this <see cref="BasePlayer" />'s death.</param>
-        public virtual void SendDeathMessage(BasePlayer killer, BasePlayer killee, Weapon weapon)
+        /// <param name="weaponType">The reason for this <see cref="BasePlayer" />'s death.</param>
+        public virtual void SendDeathMessage(BasePlayer killer, BasePlayer killee, WeaponType weaponType)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.SendDeathMessageToPlayer(Id, killer?.Id ?? InvalidId, killee?.Id ?? InvalidId, (int) weapon);
+            PlayerInternal.Instance.SendDeathMessageToPlayer(Id, killer?.Id ?? InvalidId, killee?.Id ?? InvalidId, (int)weaponType);
         }
 
         /// <summary>
@@ -2186,10 +2227,10 @@ namespace SampSharp.GameMode.World
         /// </summary>
         /// <param name="killer">The Player that killer the <paramref name="killee" />.</param>
         /// <param name="killee">The player that has been killed.</param>
-        /// <param name="weapon">The reason for this Player's death.</param>
-        public static void SendDeathMessageToAll(BasePlayer killer, BasePlayer killee, Weapon weapon)
+        /// <param name="weaponType">The reason for this Player's death.</param>
+        public static void SendDeathMessageToAll(BasePlayer killer, BasePlayer killee, WeaponType weaponType)
         {
-            PlayerInternal.Instance.SendDeathMessage(killer?.Id ?? InvalidId, killee?.Id ?? InvalidId, (int) weapon);
+            PlayerInternal.Instance.SendDeathMessage(killer?.Id ?? InvalidId, killee?.Id ?? InvalidId, (int)weaponType);
         }
 
         #endregion

--- a/src/SampSharp.GameMode/World/BasePlayer.cs
+++ b/src/SampSharp.GameMode/World/BasePlayer.cs
@@ -628,6 +628,13 @@ namespace SampSharp.GameMode.World
 
         #endregion
 
+        #region Extension Properties
+        /// <summary>
+        ///     Used for getting the first available map icon Id.
+        /// </summary>
+        public List<BaseMapIcon> MapIcons { get; set; } = new List<BaseMapIcon>();
+        #endregion
+
         #region Events
 
         /// <summary>
@@ -1697,6 +1704,7 @@ namespace SampSharp.GameMode.World
         /// <param name="color">The color of the icon, this should only be used with the square icon (ID: 0).</param>
         /// <param name="style">The style of icon.</param>
         /// <returns>True if it was successful, False otherwise (e.g. the player isn't connected).</returns>
+        [Obsolete("This method is deprecated. Consider using the BaseMapIcon class instead. iconId Parameter is already unused!")]
         public virtual bool SetMapIcon(int iconid, Vector3 position, MapIcon mapIcon, Color color,
             MapIconType style)
         {
@@ -1715,24 +1723,27 @@ namespace SampSharp.GameMode.World
         /// <param name="color">The color of the icon, this should only be used with the square icon (ID: 0).</param>
         /// <param name="style">The style of icon.</param>
         /// <returns>True if it was successful, False otherwise (e.g. the player isn't connected).</returns>
+        /// 
+        [Obsolete("This method is deprecated. Consider using the BaseMapIcon class instead. iconId Parameter is already unused!")]
         public virtual bool SetMapIcon(int iconid, Vector3 position, int mapIcon, Color color,
             MapIconType style)
         {
             AssertNotDisposed();
 
-            return PlayerInternal.Instance.SetPlayerMapIcon(Id, iconid, position.X, position.Y, position.Z, mapIcon, color,
-                (int)style);
+            var newMapIcon = new BaseMapIcon(position, (MapIcon)mapIcon, style, color);
+            return newMapIcon.Show(this);
         }
 
         /// <summary>
         ///     Removes a map icon that was set earlier for this <see cref="BasePlayer" />.
         /// </summary>
         /// <param name="iconId">The ID of the icon to remove. This is the second parameter of <see cref="SetMapIcon" />.</param>
+        [Obsolete("This method is deprecated. Consider using the BaseMapIcon class instead.")]
         public virtual void RemoveMapIcon(int iconId)
         {
             AssertNotDisposed();
 
-            PlayerInternal.Instance.RemovePlayerMapIcon(Id, iconId);
+            MapIcons[iconId].Hide(this);
         }
 
         /// <summary>

--- a/src/SampSharp.GameMode/World/Weapon.cs
+++ b/src/SampSharp.GameMode/World/Weapon.cs
@@ -1,0 +1,377 @@
+﻿using System;
+using SampSharp.GameMode.Definitions;
+
+namespace SampSharp.GameMode.World
+{
+    /// <summary>
+    /// A weapon that can be given to a <see cref="BasePlayer" />.
+    /// </summary>
+    public class Weapon
+    {
+        /// <summary>
+        /// The Id of the weapon.
+        /// </summary>
+        public WeaponType WeaponId { get; set; }
+
+        /// <summary>
+        /// The name of the weapon.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The number of bullets of the weapon.
+        /// </summary>
+        public int Bullets { get; set; }
+
+        /// <summary>
+        /// Can this weapon shoot ACTUAL bullets?
+        /// </summary>
+        public bool CanShoot { get; }
+
+        /// <summary>
+        /// The slot this weapon occupies.
+        /// </summary>
+        public int Slot { get; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="weaponId">The Id of the weapon.</param>
+        /// <param name="bullets">The number of bullets of the weapon.</param>
+        public Weapon(WeaponType weaponId, int bullets)
+        {
+            WeaponId = weaponId;
+            Name = GetWeaponName(weaponId);
+            Bullets = bullets;
+            CanShoot = CanWeaponShoot(weaponId);
+            Slot = GetWeaponSlot(weaponId);
+        }
+
+        /// <summary>
+        /// Give this weapon to a player.
+        /// </summary>
+        /// <param name="player">The player who receives this weapon.</param>
+        public void GiveToPlayer(BasePlayer player)
+        {
+            player.GiveWeapon(this, Bullets);
+        }
+        /// <summary>
+        /// Give this weapon to a player with custom bullet number.
+        /// </summary>
+        /// <param name="player">The player who receives this weapon.</param>
+        /// <param name="bullets">The number of bullets to receive.</param>
+        public void GiveToPlayer(BasePlayer player, int bullets)
+        {
+            player.GiveWeapon(this, bullets);
+        }
+
+        /// <summary>
+        /// Give this weapons to all players in a range.
+        /// </summary>
+        /// <param name="range">The range in which the players must be of the point.</param>
+        /// <param name="point">The center point.</param>
+        public void GiveToRange(float range, Vector3 point)
+        {
+            foreach (var player in BasePlayer.All)
+                if (player.IsInRangeOfPoint(range, point))
+                    player.GiveWeapon(this, Bullets);
+        }
+        /// <summary>
+        /// Give this weapons to all players in a range.
+        /// </summary>
+        /// <param name="range">The range in which the players must be of the point.</param>
+        /// <param name="point">The center point.</param>
+        /// <param name="bullets">The custom number of bullets.</param>
+        public void GiveToRange(float range, Vector3 point, int bullets)
+        {
+            foreach (var player in BasePlayer.All)
+                if (player.IsInRangeOfPoint(range, point))
+                    player.GiveWeapon(this, bullets);
+        }
+
+        /// <summary>
+        /// Get the slot this weapon occupies.
+        /// </summary>
+        /// <param name="weaponId">The id of the weapon.</param>
+        public static int GetWeaponSlot(WeaponType weaponId)
+        {
+            switch (weaponId)
+            {
+                case WeaponType.None:
+                    return 0;
+                case WeaponType.Brassknuckle:
+                    return 0;
+                case WeaponType.Golfclub:
+                    return 1;
+                case WeaponType.Nitestick:
+                    return 1;
+                case WeaponType.Knife:
+                    return 1;
+                case WeaponType.Bat:
+                    return 1;
+                case WeaponType.Shovel:
+                    return 1;
+                case WeaponType.Poolstick:
+                    return 1;
+                case WeaponType.Katana:
+                    return 1;
+                case WeaponType.Chainsaw:
+                    return 1;
+                case WeaponType.DoubleEndedDildo:
+                    return 10;
+                case WeaponType.Dildo:
+                    return 10;
+                case WeaponType.Vibrator:
+                    return 10;
+                case WeaponType.SilverVibrator:
+                    return 10;
+                case WeaponType.Flower:
+                    return 10;
+                case WeaponType.Cane:
+                    return 10;
+                case WeaponType.Grenade:
+                    return 8;
+                case WeaponType.Teargas:
+                    return 8;
+                case WeaponType.Moltov:
+                    return 8;
+                case WeaponType.Colt45:
+                    return 2;
+                case WeaponType.Silenced:
+                    return 2;
+                case WeaponType.Deagle:
+                    return 2;
+                case WeaponType.Shotgun:
+                    return 3;
+                case WeaponType.Sawedoff:
+                    return 3;
+                case WeaponType.CombatShotgun:
+                    return 3;
+                case WeaponType.Uzi:
+                    return 4;
+                case WeaponType.MP5:
+                    return 4;
+                case WeaponType.AK47:
+                    return 5;
+                case WeaponType.M4:
+                    return 5;
+                case WeaponType.Tec9:
+                    return 4;
+                case WeaponType.Rifle:
+                    return 6;
+                case WeaponType.Sniper:
+                    return 6;
+                case WeaponType.RocketLauncher:
+                    return 7;
+                case WeaponType.HeatSeeker:
+                    return 7;
+                case WeaponType.FlameThrower:
+                    return 7;
+                case WeaponType.Minigun:
+                    return 7;
+                case WeaponType.SatchelCharge:
+                    return 8;
+                case WeaponType.Detonator:
+                    return 12;
+                case WeaponType.Spraycan:
+                    return 9;
+                case WeaponType.FireExtinguisher:
+                    return 9;
+                case WeaponType.Camera:
+                    return 9;
+                case WeaponType.NightVisionGoggles:
+                    return 9;
+                case WeaponType.ThermalGoggles:
+                    return 11;
+                case WeaponType.Parachute:
+                    return 11;
+                case WeaponType.FakePistol:
+                    return 11;
+                case WeaponType.Vehicle:
+                    return -1;
+                case WeaponType.HelicopterBlades:
+                    return -1;
+                case WeaponType.Explosion:
+                    return -1;
+                case WeaponType.Drown:
+                    return -1;
+                case WeaponType.Collision:
+                    return -1;
+                case WeaponType.Connect:
+                    return -1;
+                case WeaponType.Disconnect:
+                    return -1;
+                case WeaponType.Suicide:
+                    return -1;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(weaponId), weaponId, null);
+            }
+        }
+
+        /// <summary>
+        /// Get the name of a weapon by Id.
+        /// </summary>
+        /// <param name="weaponId"></param>
+        /// <returns>The weapon's name</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private static string GetWeaponName(WeaponType weaponId)
+        {
+            switch (weaponId)
+            {
+                case WeaponType.None:
+                    return "None";
+                case WeaponType.Brassknuckle:
+                    return "Brass Knuckle";
+                case WeaponType.Golfclub:
+                    return "Golf Club";
+                case WeaponType.Nitestick:
+                    return "Night Stick";
+                case WeaponType.Knife:
+                    return "Knife"; 
+                case WeaponType.Bat:
+                    return "Bat";
+                case WeaponType.Shovel:
+                    return "Shovel";
+                case WeaponType.Poolstick:
+                    return "Cue Stick";
+                case WeaponType.Katana:
+                    return "Katana";
+                case WeaponType.Chainsaw:
+                    return "Chainsaw";
+                case WeaponType.DoubleEndedDildo:
+                    return "Double-ended Dildo";
+                case WeaponType.Dildo:
+                    return "Dildo";
+                case WeaponType.Vibrator:
+                    return "Vibrator";
+                case WeaponType.SilverVibrator:
+                    return "Silver Vibrator";
+                case WeaponType.Flower:
+                    return "Flower";
+                case WeaponType.Cane:
+                    return "Cane";
+                case WeaponType.Grenade:
+                    return "Grenade";
+                case WeaponType.Teargas:
+                    return "Tear Gas";
+                case WeaponType.Moltov:
+                    return "Molotov";
+                case WeaponType.Colt45:
+                    return "Colt-45";
+                case WeaponType.Silenced:
+                    return "Silenced Pistol";
+                case WeaponType.Deagle:
+                    return "Desert Eagle";
+                case WeaponType.Shotgun:
+                    return "Shotgun";
+                case WeaponType.Sawedoff:
+                    return "Sawed-Off Shotgun";
+                case WeaponType.CombatShotgun:
+                    return "Combat Shotgun";
+                case WeaponType.Uzi:
+                    return "UZI";
+                case WeaponType.MP5:
+                    return "MP5";
+                case WeaponType.AK47:
+                    return "AK47";
+                case WeaponType.M4:
+                    return "M4";
+                case WeaponType.Tec9:
+                    return "Tec-9";
+                case WeaponType.Rifle:
+                    return "Rifle";
+                case WeaponType.Sniper:
+                    return "Sniper Rifle";
+                case WeaponType.RocketLauncher:
+                    return "RPG";
+                case WeaponType.HeatSeeker:
+                    return "Heat-Seeking Rocket";
+                case WeaponType.FlameThrower:
+                    return "Flamethrower";
+                case WeaponType.Minigun:
+                    return "Minigun";
+                case WeaponType.SatchelCharge:
+                    return "Satchel Charge";
+                case WeaponType.Detonator:
+                    return "Detonator";
+                case WeaponType.Spraycan:
+                    return "Spray Can";
+                case WeaponType.FireExtinguisher:
+                    return "Fire Extinguisher";
+                case WeaponType.Camera:
+                    return "Camera";
+                case WeaponType.NightVisionGoggles:
+                    return "Night Vision Goggles";
+                case WeaponType.ThermalGoggles:
+                    return "Thermal Goggles";
+                case WeaponType.Parachute:
+                    return "Parachute";
+                case WeaponType.FakePistol:
+                    return "Fake Pistol";
+                case WeaponType.Vehicle:
+                    return "Vehicle";
+                case WeaponType.HelicopterBlades:
+                    return "Helicopter Blades";
+                case WeaponType.Explosion:
+                    return "Explosion";
+                case WeaponType.Drown:
+                    return "Drown";
+                case WeaponType.Collision:
+                    return "Collision";
+                case WeaponType.Connect:
+                    return "Connection";
+                case WeaponType.Disconnect:
+                    return "Disconnection";
+                case WeaponType.Suicide:
+                    return "Suicide";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(weaponId), weaponId, null);
+            }
+        }
+
+        /// <summary>
+        /// Can this weapon shoot bullets?
+        /// </summary>
+        /// <remarks>throwables and spray cans are NOT considered bullets</remarks>
+        /// <returns>
+        /// true if the weapon can shoot bullets.
+        /// false if the weapon cannot shoot bullet.
+        /// </returns>
+        private static bool CanWeaponShoot(WeaponType weaponId)
+        {
+            if (weaponId == WeaponType.Colt45)
+                return true;
+            if (weaponId == WeaponType.Silenced)
+                return true;
+            if (weaponId == WeaponType.Deagle)
+                return true;
+            if (weaponId == WeaponType.Shotgun)
+                return true;
+            if (weaponId == WeaponType.Sawedoff)
+                return true;
+            if (weaponId == WeaponType.CombatShotgun)
+                return true;
+            if (weaponId == WeaponType.Uzi)
+                return true;
+            if (weaponId == WeaponType.MP5)
+                return true;
+            if (weaponId == WeaponType.AK47)
+                return true;
+            if (weaponId == WeaponType.M4)
+                return true;
+            if (weaponId == WeaponType.Tec9)
+                return true;
+            if (weaponId == WeaponType.Rifle)
+                return true;
+            if (weaponId == WeaponType.Sniper)
+                return true;
+            if (weaponId == WeaponType.RocketLauncher)
+                return true;
+            if (weaponId == WeaponType.HeatSeeker)
+                return true;
+            if (weaponId == WeaponType.Minigun)
+                return true;
+            return false;
+        }
+    }
+}

--- a/src/SampSharp/SampSharp.vcxproj
+++ b/src/SampSharp/SampSharp.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SampSharp</RootNamespace>
     <ProjectName>SampSharp</ProjectName>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -23,12 +23,12 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/src/TestMode.DotNetFramework/App.config
+++ b/src/TestMode.DotNetFramework/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/TestMode.DotNetFramework/App.config
+++ b/src/TestMode.DotNetFramework/App.config
@@ -1,29 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/TestMode.DotNetFramework/TestMode.DotNetFramework.csproj
+++ b/src/TestMode.DotNetFramework/TestMode.DotNetFramework.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>TestMode</RootNamespace>
     <AssemblyName>TestMode.DotNetFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/src/TestMode.DotNetFramework/TestMode.DotNetFramework.csproj
+++ b/src/TestMode.DotNetFramework/TestMode.DotNetFramework.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>TestMode</RootNamespace>
     <AssemblyName>TestMode.DotNetFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />


### PR DESCRIPTION
Changes the way weapons are handled by S#, splitting the current Weapon enum to a `Weapon` class, which represents an actual weapon, with bullets, which can be given to a player or all players in a range, and an enum called `WeaponType` which is the previous weapon enum.

Solves issue #311 