### PR TITLE
Fixed transparent color in Color.FromInteger

### DIFF
--- a/src/SampSharp.GameMode/SAMP/Color.cs
+++ b/src/SampSharp.GameMode/SAMP/Color.cs
@@ -1097,6 +1097,7 @@ namespace SampSharp.GameMode.SAMP
                     b = (byte) (color & 0xFF);
                     g = (byte) ((color >>= 8) & 0xFF);
                     r = (byte) ((color >> 8) & 0xFF);
+                    a = (byte) 0xFF;
                     break;
             }
             return new Color(r, g, b, a);


### PR DESCRIPTION
If format RGB is used, color is transparent because the default alpha is 0 and does not change in this case.