### PR TITLE
Added PlayerCancelClickTextDraw event

### DIFF
--- a/src/SampSharp.GameMode/BaseMode.callbacks.cs
+++ b/src/SampSharp.GameMode/BaseMode.callbacks.cs
@@ -494,14 +494,21 @@ namespace SampSharp.GameMode
         [Callback]
         internal bool OnPlayerClickTextDraw(int playerid, int clickedid)
         {
-            var clicked = clickedid == TextDraw.InvalidId ? null : TextDraw.Find(clickedid);
+            if (clickedid == TextDraw.InvalidId)
+            {
+                var player = BasePlayer.FindOrCreate(playerid);
+                OnPlayerCancelClickTextDraw(player, new PlayerEventArgs(player));
+            }
+            else
+            {
+                var clicked = TextDraw.Find(clickedid);
 
-            if (clickedid != TextDraw.InvalidId && clicked == null)
-                return true;
+                if (clicked == null)
+                    return true;
 
-            var player = BasePlayer.FindOrCreate(playerid);
-            OnPlayerClickTextDraw(player, new ClickTextDrawEventArgs(player, clicked));
-
+                var player = BasePlayer.FindOrCreate(playerid);
+                OnPlayerClickTextDraw(player, new ClickTextDrawEventArgs(player, clicked));
+            }
             return true;
         }
 

--- a/src/SampSharp.GameMode/BaseMode.events.cs
+++ b/src/SampSharp.GameMode/BaseMode.events.cs
@@ -357,7 +357,8 @@ namespace SampSharp.GameMode
 
         /// <summary>
         ///     Occurs when the <see cref="OnPlayerClickTextDraw(BasePlayer,ClickTextDrawEventArgs)" /> callback is being called.
-        ///     This callback is called when a player clicks on a textdraw or cancels the select mode(ESC).
+        ///     This callback is called when a player clicks on a textdraw. It is not called when player cancels the select
+        ///     mode (ESC).
         /// </summary>
         /// <remarks>
         ///     The clickable area is defined by <see cref="TextDraw.Width" /> and <see cref="TextDraw.Height" />.
@@ -369,9 +370,16 @@ namespace SampSharp.GameMode
         ///     being
         ///     called.
         ///     This callback is called when a player clicks on a player-textdraw. It is not called when player cancels the select
-        ///     mode (ESC) - however, <see cref="OnPlayerClickTextDraw(BasePlayer,ClickTextDrawEventArgs)" /> is.
+        ///     mode (ESC).
         /// </summary>
         public event EventHandler<ClickPlayerTextDrawEventArgs> PlayerClickPlayerTextDraw;
+
+        /// <summary>
+        ///     Occurs when the <see cref="OnPlayerCancelClickTextDraw(BasePlayer, PlayerEventArgs)" /> callback is being called.
+        ///     This callback is called when a player cancels the textdraw select mode(ESC).
+        /// </summary>
+        public event EventHandler<PlayerEventArgs> PlayerCancelClickTextDraw;
+
 
         /// <summary>
         ///     Occurs when the <see cref="OnPlayerClickPlayer(BasePlayer, ClickPlayerEventArgs)" /> callback is being called.
@@ -927,6 +935,17 @@ namespace SampSharp.GameMode
         {
             PlayerClickPlayerTextDraw?.Invoke(player, e);
         }
+
+        /// <summary>
+        ///     Raises the <see cref="PlayerCancelClickTextDraw" /> event.
+        /// </summary>
+        /// <param name="player">The player triggering the event.</param>
+        /// <param name="e">An <see cref="PlayerEventArgs" /> that contains the event data. </param>
+        protected virtual void OnPlayerCancelClickTextDraw(BasePlayer player, PlayerEventArgs e)
+        {
+            PlayerCancelClickTextDraw?.Invoke(player, e);
+        }
+
 
         /// <summary>
         ///     Raises the <see cref="PlayerClickPlayer" /> event.

--- a/src/SampSharp.GameMode/Controllers/BasePlayerController.cs
+++ b/src/SampSharp.GameMode/Controllers/BasePlayerController.cs
@@ -60,15 +60,12 @@ namespace SampSharp.GameMode.Controllers
             gameMode.PlayerTakeDamage += (sender, args) => (sender as BasePlayer)?.OnTakeDamage(args);
             gameMode.PlayerGiveDamage += (sender, args) => (sender as BasePlayer)?.OnGiveDamage(args);
             gameMode.PlayerClickMap += (sender, args) => (sender as BasePlayer)?.OnClickMap(args);
-            gameMode.PlayerClickTextDraw += (sender, args) =>
-            {
-                if (args.TextDraw == null)
-                    (sender as BasePlayer)?.OnCancelClickTextDraw(args);
-                else
-                    (sender as BasePlayer)?.OnClickTextDraw(args);
-            };
+            gameMode.PlayerClickTextDraw +=
+                (sender, args) => (sender as BasePlayer)?.OnClickTextDraw(args);
             gameMode.PlayerClickPlayerTextDraw +=
                 (sender, args) => (sender as BasePlayer)?.OnClickPlayerTextDraw(args);
+            gameMode.PlayerCancelClickTextDraw +=
+                (sender, args) => (sender as BasePlayer)?.OnCancelClickTextDraw(args);
             gameMode.PlayerClickPlayer += (sender, args) => (sender as BasePlayer)?.OnClickPlayer(args);
             gameMode.PlayerEditGlobalObject += (sender, args) => (sender as BasePlayer)?.OnEditGlobalObject(args);
             gameMode.PlayerEditPlayerObject += (sender, args) => (sender as BasePlayer)?.OnEditPlayerObject(args);

--- a/src/SampSharp.GameMode/World/BasePlayer.cs
+++ b/src/SampSharp.GameMode/World/BasePlayer.cs
@@ -830,7 +830,8 @@ namespace SampSharp.GameMode.World
 
         /// <summary>
         ///     Occurs when the <see cref="OnClickTextDraw" /> is being called.
-        ///     This callback is called when a player clicks on a textdraw.
+        ///     This callback is called when a player clicks on a textdraw. It is not called when player cancels the select
+        ///     mode (ESC)
         /// </summary>
         /// <remarks>
         ///     The clickable area is defined by <see cref="TextDraw.Width" /> and <see cref="TextDraw.Width" />. The x and y
@@ -840,17 +841,17 @@ namespace SampSharp.GameMode.World
         public event EventHandler<ClickTextDrawEventArgs> ClickTextDraw;
 
         /// <summary>
+        ///     Occurs when the <see cref="OnClickPlayerTextDraw" /> is being called.
+        ///     This callback is called when a player clicks on a player-textdraw. It is not called when player cancels the select
+        ///     mode (ESC).
+        /// </summary>
+        public event EventHandler<ClickPlayerTextDrawEventArgs> ClickPlayerTextDraw;
+
+        /// <summary>
         ///     Occurs when the <see cref="OnCancelClickTextDraw" /> is being called.
         ///     This callback is called when a player cancels the textdraw select mode(ESC).
         /// </summary>
-        public event EventHandler<EventArgs> CancelClickTextDraw;
-
-        /// <summary>
-        ///     Occurs when the <see cref="OnClickPlayerTextDraw" /> is being called.
-        ///     This callback is called when a player clicks on a player-textdraw. It is not called when player cancels the select
-        ///     mode (ESC) - however, <see cref="OnClickTextDraw" /> is.
-        /// </summary>
-        public event EventHandler<ClickPlayerTextDrawEventArgs> ClickPlayerTextDraw;
+        public event EventHandler<PlayerEventArgs> CancelClickTextDraw;
 
         /// <summary>
         ///     Occurs when the <see cref="OnClickPlayer" /> is being called.
@@ -2468,21 +2469,21 @@ namespace SampSharp.GameMode.World
         }
 
         /// <summary>
-        ///     Raises the <see cref="CancelClickTextDraw" /> event.
-        /// </summary>
-        /// <param name="e">An <see cref="PlayerEventArgs" /> that contains the event data. </param>
-        public virtual void OnCancelClickTextDraw(EventArgs e)
-        {
-            CancelClickTextDraw?.Invoke(this, e);
-        }
-
-        /// <summary>
         ///     Raises the <see cref="ClickPlayerTextDraw" /> event.
         /// </summary>
         /// <param name="e">An <see cref="ClickPlayerTextDrawEventArgs" /> that contains the event data. </param>
         public virtual void OnClickPlayerTextDraw(ClickPlayerTextDrawEventArgs e)
         {
             ClickPlayerTextDraw?.Invoke(this, e);
+        }
+
+        /// <summary>
+        ///     Raises the <see cref="CancelClickTextDraw" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="PlayerEventArgs" /> that contains the event data. </param>
+        public virtual void OnCancelClickTextDraw(PlayerEventArgs e)
+        {
+            CancelClickTextDraw?.Invoke(this, e);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #304
Now click cancelling is fully independent from clicking the textdraw and has its own event on BaseMode level allowing all the controllers to catch it directly.