### PR TITLE
[GM] Fixed wrong BasePlayer returned on NPC connection

### DIFF
--- a/src/SampSharp.GameMode/SAMP/Server.cs
+++ b/src/SampSharp.GameMode/SAMP/Server.cs
@@ -165,25 +165,15 @@ namespace SampSharp.GameMode.SAMP
         /// <param name="name">The name the NPC should connect as. Must follow the same rules as normal player names.</param>
         /// <param name="script">The NPC script name that is located in the npcmodes folder (without the .amx extension).</param>
         /// <returns>
-        ///     An instance of <see cref="BasePlayer" /> based on the first available player slot. If no slots are available,
-        ///     null.
+        ///     An instance of <see cref="NPC" />
         /// </returns>
-        public static BasePlayer ConnectNPC(string name, string script)
+        public static NPC ConnectNPC(string name, string script)
         {
-            var id = -1;
-            var max = MaxPlayers;
+            if (BasePlayer.FindByName(name) != null)
+                throw new Exception($"The name \"{name}\" is already used in game");
 
-            for (var i = 0; i < max; i++)
-                if (!ServerInternal.Instance.IsPlayerConnected(i))
-                    id = i;
-
-            if (id == -1)
-                return null;
-
-            ServerInternal.Instance.ConnectNPC(name, script);
-            var result = BasePlayer.FindOrCreate(id);
-            result.IsNpcOverride = true;
-            return result;
+            NPC npc = new NPC(name, script);
+            return npc;
         }
 
         /// <summary>

--- a/src/SampSharp.GameMode/World/BasePlayer.cs
+++ b/src/SampSharp.GameMode/World/BasePlayer.cs
@@ -58,6 +58,26 @@ namespace SampSharp.GameMode.World
         ///     Maximum length of the text in a chat bubble.
         /// </summary>
         public const int MaxChatBubbleLength = 144;
+
+        /// <summary>
+        ///     Finds a <see cref="BasePlayer"/> from the given <paramref name="name"/>
+        /// </summary>
+        /// <param name="name">The name of the BasePlayer to find</param>
+        /// <returns>The found BasePlayer</returns>
+        public static BasePlayer FindByName(string name)
+        {
+            BasePlayer result = null;
+            for (int i = 0; i < Server.MaxPlayers; i++)
+            {
+                if (BasePlayer.Find(i) != null)
+                {
+                    BasePlayer p = BasePlayer.Find(i);
+                    if (p.Name.Equals(name))
+                        result = p;
+                }
+            }
+            return result;
+        }
         
         #region Constructors
 

--- a/src/SampSharp.GameMode/World/NPC.cs
+++ b/src/SampSharp.GameMode/World/NPC.cs
@@ -1,0 +1,90 @@
+﻿// SampSharp
+// Copyright 2017 Tim Potze
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using SampSharp.GameMode.Events;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using static SampSharp.GameMode.SAMP.Server;
+
+namespace SampSharp.GameMode.World
+{
+    /// <summary>
+    ///     Represents a SA-MP NPC
+    /// </summary>
+    public class NPC
+    {
+        internal string Name { get; }
+
+        #region Constructors
+
+        /// <summary>
+        ///     Initialize a new instance of the <see cref="NPC"/> class.
+        /// </summary>
+        /// <param name="name">The name the NPC should connect as. Must follow the same rules as normal player names.</param>
+        /// <param name="script">The NPC script name that is located in the npcmodes folder (without the .amx extension).</param>
+        public NPC(string name, string script)
+        {
+            ServerInternal.Instance.ConnectNPC(name, script);
+            Name = name;
+            this.FindInstance();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        ///     The <see cref="BasePlayer"/> of the NPC
+        /// </summary>
+        public BasePlayer PlayerInstance { get; set; }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        ///     Occurs when the NPC instance has been connected
+        /// </summary>
+        public EventHandler<ConnectionEventArgs> Connected;
+
+        #endregion
+
+        #region Methods
+
+        private void FindInstance()
+        {
+            Thread t = new Thread(new ThreadStart(() => {
+                BasePlayer player;
+                while(PlayerInstance == null)
+                {
+                    for(int i=0; i < ServerInternal.Instance.GetMaxPlayers(); i++)
+                    {
+                        player = BasePlayer.Find(i);
+                        if (player == null) continue;
+                        if (player.Name.Equals(Name) && player.IsConnected && player.IsNPC)
+                        {
+                            PlayerInstance = player;
+                            Connected?.Invoke(this, new ConnectionEventArgs(player.Id, player.IP, -1));
+                        }
+                    }
+                }
+            }));
+            t.Start();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Actually the ConnectNPC method returns a empty BasePlayer instance. The problem is we can't know when the NPC will be connected to the server ..

So I've created a "NPC" class with a Thread in it to loop through all connected players and check if a player matches with the NPC.
When a player matches with the NPC (same name, and "IsNPC" is true), an event is triggered to be able to make some actions after the NPC connection.