### PR TITLE
Fixed silent fail on player name change

### DIFF
--- a/src/SampSharp.GameMode/World/BasePlayer.cs
+++ b/src/SampSharp.GameMode/World/BasePlayer.cs
@@ -116,7 +116,13 @@ namespace SampSharp.GameMode.World
                 PlayerInternal.Instance.GetPlayerName(Id, out var name, MaxNameLength);
                 return name;
             }
-            set => PlayerInternal.Instance.SetPlayerName(Id, value);
+            set
+            {
+                if(PlayerInternal.Instance.SetPlayerName(Id, value) == -1)
+                {
+                    throw new InvalidOperationException("The name is already in use, too long or has invalid characters.");
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes #387
Error description taken from here: https://open.mp/docs/scripting/functions/SetPlayerName

Changed to InvalidOperationException as you requested, I agree with that.

I revised all the other calls into SAMP and return codes, seems no more checks like this one are needed.
I ignored the return codes for "Player not exists", "Vehicle not exists", "Object not exists", and so on... because if those are destroyed then the SampSharp instance for that entity will be disposed.
And also I ignored the parameters check errors, because I think we should add own checks in SampSharp to throw descriptive and specific errors. SAMP is returning only one error code for different situations.

PS: sorry for creating new PR (the old one is #388), I messed up the old fork 😅