### PR TITLE
Fix commands overloading

### DIFF
--- a/src/SampSharp.GameMode/SAMP/Commands/CommandsManager.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/CommandsManager.cs
@@ -218,7 +218,7 @@ namespace SampSharp.GameMode.SAMP.Commands
         public ICommand GetCommandForText(BasePlayer player, string commandText)
         {
             ICommand candidate = null;
-            var isFullMath = false;
+            var isFullMatch = false;
             var candidateLength = 0;
 
             foreach (var command in _commands)
@@ -227,9 +227,9 @@ namespace SampSharp.GameMode.SAMP.Commands
                 {
                     case CommandCallableResponse.True:
 
-                        if (candidateLength < matchedNameLength || candidateLength == matchedNameLength && !isFullMath)
+                        if (candidateLength < matchedNameLength || candidateLength == matchedNameLength && !isFullMatch)
                         {
-                            isFullMath = true;
+                            isFullMatch = true;
                             candidateLength = matchedNameLength;
                             candidate = command;
                         }

--- a/src/SampSharp.GameMode/SAMP/Commands/DefaultCommand.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/DefaultCommand.cs
@@ -294,7 +294,7 @@ namespace SampSharp.GameMode.SAMP.Commands
                 if (!name.Matches(commandText, IsCaseIgnored)) continue;
 
                 matchedNameLength = name.Length;
-                commandText = commandText.Substring(name.Length);
+                commandText = commandText.Substring(name.Length).Trim();
                 var result = GetArguments(commandText, out _, out var argumentsLength);
                 matchedNameLength += argumentsLength;
                 return result

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/EnumType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/EnumType.cs
@@ -56,13 +56,13 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
             output = null;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
                 return false;
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
             var lowerWord = word.ToLower();
 
             // find all candiates containing the input word, case insensitive.

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/FloatType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/FloatType.cs
@@ -36,13 +36,13 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
             output = null;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
                 return false;
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
 
             // Unify input culture.
             var preProcessedWord = word;

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/IntegerType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/IntegerType.cs
@@ -39,14 +39,14 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
             output = null;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
                 return false;
 
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
 
 
             // Regular base 10 numbers (eg. 14143)

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/NullableEnumType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/NullableEnumType.cs
@@ -57,13 +57,13 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
             output = null;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
                 return false;
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
             var lowerWord = word.ToLower();
 
             // find all candiates containing the input word, case insensitive.

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/PlayerType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/PlayerType.cs
@@ -37,13 +37,13 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
             output = null;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
                 return false;
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
 
             // find a player with a matching id.
             if (int.TryParse(word, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/TextType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/TextType.cs
@@ -33,15 +33,15 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.Trim();
+            commandText = commandText.Trim();
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
             {
                 output = null;
                 return false;
             }
 
-            output = text;
+            output = commandText;
             commandText = string.Empty;
             return true;
         }

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/VehicleType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/VehicleType.cs
@@ -37,13 +37,13 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
             output = null;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
                 return false;
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
 
             // find a vehicle with a matching id.
             if (!int.TryParse(word, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id)) 

--- a/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/WordType.cs
+++ b/src/SampSharp.GameMode/SAMP/Commands/ParameterTypes/WordType.cs
@@ -35,15 +35,15 @@ namespace SampSharp.GameMode.SAMP.Commands.ParameterTypes
         /// </returns>
         public bool Parse(ref string commandText, out object output, bool isNullable)
         {
-            var text = commandText.TrimStart();
+            commandText = commandText.TrimStart();
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(commandText))
             {
                 output = null;
                 return false;
             }
 
-            var word = text.Split(' ').First();
+            var word = commandText.Split(' ').First();
 
             commandText = commandText.Substring(word.Length).TrimStart(' ');
 


### PR DESCRIPTION
This fixes #392 

I don't know which one of the fixes you prefer, the ICommandParameterType implementations or the trim inside the CanInvoke. I did the both here.

Tested for a day, fixes the issue and not noticed any new problems.