### PR TITLE
Fix Get/Set WindowsParameters being inverted compared to everything else

### DIFF
--- a/src/SampSharp.Core.UnitTests/SampSharp.Core.UnitTests.csproj
+++ b/src/SampSharp.Core.UnitTests/SampSharp.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/src/SampSharp.Core/SampSharp.Core.csproj
+++ b/src/SampSharp.Core/SampSharp.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Title>SampSharp Server Core</Title>
     <Description>The core library of SampSharp which manages the communication with the SA-MP server.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/SampSharp.Entities/SAMP/Commands/CommandServiceBase.cs
+++ b/src/SampSharp.Entities/SAMP/Commands/CommandServiceBase.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Reflection;
 using SampSharp.Entities.SAMP.Commands.Parsers;
 using SampSharp.Entities.Utilities;
+using MethodInvoker = SampSharp.Entities.Utilities.MethodInvoker;
 
 namespace SampSharp.Entities.SAMP.Commands;
 

--- a/src/SampSharp.Entities/SAMP/Components/PlayerTextDraw.cs
+++ b/src/SampSharp.Entities/SAMP/Components/PlayerTextDraw.cs
@@ -18,6 +18,7 @@ namespace SampSharp.Entities.SAMP;
 /// <summary>Represents a component which provides the data and functionality of a per-player textdraw.</summary>
 public class PlayerTextDraw : Component
 {
+    private Vector2 _position;
     private TextDrawAlignment _alignment = TextDrawAlignment.Left;
     private Color _backColor = Color.Black;
     private Color _boxColor = Color.Transparent;
@@ -36,7 +37,7 @@ public class PlayerTextDraw : Component
     /// <summary>Constructs an instance of PlayerTextDraw, should be used internally.</summary>
     protected PlayerTextDraw(Vector2 position, string text)
     {
-        Position = position;
+        _position = position;
         _text = text;
     }
 
@@ -211,7 +212,17 @@ public class PlayerTextDraw : Component
     }
 
     /// <summary>Gets the position of this textdraw.</summary>
-    public virtual Vector2 Position { get; }
+    public virtual Vector2 Position
+    {
+        get => _position;
+        set
+        {
+            _position = value;
+            GetComponent<NativePlayerTextDraw>()
+                .PlayerTextDrawSetPos(value.X, value.Y);
+        }
+    }
+
 
 
     /// <summary>Sets the preview object rotation and zoom of this textdraw.</summary>

--- a/src/SampSharp.Entities/SAMP/Components/TextDraw.cs
+++ b/src/SampSharp.Entities/SAMP/Components/TextDraw.cs
@@ -18,6 +18,7 @@ namespace SampSharp.Entities.SAMP;
 /// <summary>Represents a component which provides the data and functionality of a textdraw.</summary>
 public class TextDraw : Component
 {
+    private Vector2 _position = Vector2.Zero;
     private TextDrawAlignment _alignment = TextDrawAlignment.Left;
     private Color _backColor = Color.Black;
     private Color _boxColor = Color.Transparent;
@@ -36,7 +37,7 @@ public class TextDraw : Component
     /// <summary>Constructs an instance of TextDraw, should be used internally.</summary>
     protected TextDraw(Vector2 position, string text)
     {
-        Position = position;
+        _position = position;
         _text = text;
     }
 
@@ -211,7 +212,17 @@ public class TextDraw : Component
     }
 
     /// <summary>Gets the position of this textdraw.</summary>
-    public virtual Vector2 Position { get; }
+    public virtual Vector2 Position 
+    {
+        get => _position;
+        set
+        {
+            _position = value;
+            GetComponent<NativeTextDraw>()
+                .TextDrawSetPos(value.X, value.Y);
+        }
+    
+    }
 
     /// <summary>Sets the preview object rotation and zoom of this textdraw.</summary>
     /// <param name="rotation">The rotation of the preview object.</param>

--- a/src/SampSharp.Entities/SAMP/Components/Vehicle.cs
+++ b/src/SampSharp.Entities/SAMP/Components/Vehicle.cs
@@ -618,6 +618,11 @@ public sealed class Vehicle : Component
     public void SetWindowsParameters(VehicleParameterValue driver, VehicleParameterValue passenger, VehicleParameterValue backLeft,
         VehicleParameterValue backRight)
     {
+        if (driver != VehicleParameterValue.Unset) driver = (VehicleParameterValue)(driver == VehicleParameterValue.On ? 0 : 1);
+        if (passenger != VehicleParameterValue.Unset) passenger = (VehicleParameterValue)(passenger == VehicleParameterValue.On ? 0 : 1);
+        if (backLeft != VehicleParameterValue.Unset) backLeft = (VehicleParameterValue)(backLeft == VehicleParameterValue.On ? 0 : 1);
+        if (backRight != VehicleParameterValue.Unset) backRight = (VehicleParameterValue)(backRight == VehicleParameterValue.On ? 0 : 1);
+
         GetComponent<NativeVehicle>()
             .SetVehicleParamsCarWindows((int)driver, (int)passenger, (int)backLeft, (int)backRight);
     }
@@ -632,6 +637,12 @@ public sealed class Vehicle : Component
     {
         GetComponent<NativeVehicle>()
             .GetVehicleParamsCarWindows(out var tmpDriver, out var tmpPassenger, out var tmpBackLeft, out var tmpBackRight);
+
+        if (tmpDriver != -1) tmpDriver = (tmpDriver == 0 ? 1 : 0);
+        if (tmpPassenger != -1) tmpPassenger = (tmpPassenger == 0 ? 1 : 0);
+        if (tmpBackLeft != -1) tmpBackLeft = (tmpBackLeft == 0 ? 1 : 0);
+        if (tmpBackRight != -1) tmpBackRight = (tmpBackRight == 0 ? 1 : 0);
+
 
         driver = (VehicleParameterValue)tmpDriver;
         passenger = (VehicleParameterValue)tmpPassenger;

--- a/src/SampSharp.Entities/SAMP/Components/Vehicle.cs
+++ b/src/SampSharp.Entities/SAMP/Components/Vehicle.cs
@@ -350,6 +350,17 @@ public class Vehicle : Component
     public virtual bool IsSirenOn => GetComponent<NativeVehicle>()
         .GetVehicleParamsSirenState() == 1;
 
+    /// <summary>Gets and sets the value indicating this vehicle's siren is on. (Setting added open.mp v1.1.0.2612) </summary>
+    public virtual bool Siren
+    {
+        get => IsSirenOn;
+        set => GetComponent<NativeVehicle>()
+                .ToggleVehicleSirenEnabled(value);
+        
+    }
+
+
+
     /// <summary>Gets or sets the rotation of this vehicle.</summary>
     /// <remarks>Only the Z angle can be set!</remarks>
     public virtual Vector3 Rotation
@@ -394,6 +405,60 @@ public class Vehicle : Component
                 .GetVehicleRotationQuat(out var w, out var x, out var y, out var z);
             return new Quaternion(x, y, z, w);
         }
+    }
+
+    /// <summary>
+    /// Sets and gets the respawn delay of the vehicle. (Added  open.mp  v1.1.0.2612)
+    /// </summary>
+    public virtual int RespawnDelay
+    {
+        get => GetComponent<NativeVehicle>()
+            .GetVehicleRespawnDelay();
+
+        set => GetComponent<NativeVehicle>()
+                .SetVehicleRespawnDelay(value);
+        
+    }
+
+    /// <summary>
+    /// Gets the cab (towing vehicle) (Added  open.mp  v1.1.0.2612)
+    /// </summary>
+    public virtual EntityId GetVehicleCab
+    {
+        get
+        {
+             var id = GetComponent<NativeVehicle>()
+                    .GetVehicleCab();
+
+            return id == 0 ? EntityId.Empty : SampEntities.GetVehicleId(id);
+        }
+    }
+
+    /// <summary>
+    /// Gets the hydra reactor (thruster) angle (Added  open.mp  v1.1.0.2612)
+    /// </summary>
+    public virtual int HydraReactorAngle
+    {
+        get => GetComponent<NativeVehicle>()
+                   .GetVehicleHydraReactorAngle();
+    }
+
+    /// <summary>
+    /// Gets the state of the plane landing gears (Added  open.mp  v1.1.0.2612)
+    /// </summary>
+    public virtual LandingGearState LandingGearState
+    {
+        get => (LandingGearState)GetComponent<NativeVehicle>()
+                   .GetVehicleLandingGearState();
+    }
+
+    /// <summary>
+    /// Gets the train speed for the vehicle (Added  open.mp  v1.1.0.2612)
+    /// </summary>
+    public virtual float TrainSpeed
+    {
+        get => GetComponent<NativeVehicle>()
+                   .GetVehicleTrainSpeed();
     }
 
     /// <summary>
@@ -705,6 +770,16 @@ public class Vehicle : Component
         GetComponent<NativeVehicle>()
             .ChangeVehicleColor(color1, color2);
     }
+
+    /// <summary>Get this vehicle's primary and secondary colors.</summary>
+    /// <param name="color1">The new vehicle's primary Color ID.</param>
+    /// <param name="color2">The new vehicle's secondary Color ID.</param>
+    public virtual void GetColor(out int color1, out int color2)
+    {
+        GetComponent<NativeVehicle>()
+            .GetVehicleColours(out color1, out color2);
+    }
+
 
     /// <summary>Change this vehicle's paintjob (for plain colors see <see cref="ChangeColor" />).</summary>
     /// <param name="paintjobId">The ID of the paintjob to apply. Use 3 to remove a paintjob.</param>

--- a/src/SampSharp.Entities/SAMP/Definitions/LandingGearState.cs
+++ b/src/SampSharp.Entities/SAMP/Definitions/LandingGearState.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SampSharp.Entities.SAMP
+{
+    public enum LandingGearState
+    {
+        Down = 0,
+        Up = 1,
+    }
+}

--- a/src/SampSharp.Entities/SAMP/NativeComponents/NativePlayerTextDraw.cs
+++ b/src/SampSharp.Entities/SAMP/NativeComponents/NativePlayerTextDraw.cs
@@ -41,6 +41,12 @@ public class NativePlayerTextDraw : NativeComponent
     }
 
     [NativeMethod]
+    public virtual void PlayerTextDrawSetPos(float x, float y)
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
     public virtual bool PlayerTextDrawLetterSize(float x, float y)
     {
         throw new NativeNotImplementedException();
@@ -147,4 +153,5 @@ public class NativePlayerTextDraw : NativeComponent
     {
         throw new NativeNotImplementedException();
     }
+
 }

--- a/src/SampSharp.Entities/SAMP/NativeComponents/NativeTextDraw.cs
+++ b/src/SampSharp.Entities/SAMP/NativeComponents/NativeTextDraw.cs
@@ -30,6 +30,12 @@ public class NativeTextDraw : BaseNativeComponent
     }
 
     [NativeMethod]
+    public virtual void TextDrawSetPos(float x, float y)
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
     public virtual bool TextDrawLetterSize(float x, float y)
     {
         throw new NativeNotImplementedException();

--- a/src/SampSharp.Entities/SAMP/NativeComponents/NativeVehicle.cs
+++ b/src/SampSharp.Entities/SAMP/NativeComponents/NativeVehicle.cs
@@ -265,4 +265,52 @@ public class NativeVehicle : BaseNativeComponent
     {
         throw new NativeNotImplementedException();
     }
+
+    [NativeMethod]
+    public virtual int GetVehicleRespawnDelay()
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
+    public virtual int SetVehicleRespawnDelay(int delay)
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
+    public virtual int GetVehicleCab()
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
+    public virtual int GetVehicleColours(out int col1, out int col2)
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
+    public virtual int GetVehicleHydraReactorAngle()
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
+    public virtual int GetVehicleLandingGearState()
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
+    public virtual float GetVehicleTrainSpeed()
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod] 
+    public virtual int ToggleVehicleSirenEnabled(bool toggle)
+    {
+        throw new NativeNotImplementedException(); 
+    }
 }

--- a/src/SampSharp.Entities/SampSharp.Entities.csproj
+++ b/src/SampSharp.Entities/SampSharp.Entities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Title>SampSharp Entities</Title>
     <Description>An EntityComponentSystem framework for SampSharp.</Description>
   </PropertyGroup>

--- a/src/SampSharp.GameMode/Display/PlayerTextDraw.Internal.cs
+++ b/src/SampSharp.GameMode/Display/PlayerTextDraw.Internal.cs
@@ -28,6 +28,13 @@ public partial class PlayerTextDraw
             throw new NativeNotImplementedException();
         }
 
+
+        [NativeMethod]
+        public virtual void PlayerTextDrawSetPos(int playerid, int text, float x, float y)
+        {
+            throw new NativeNotImplementedException();
+        }
+
         [NativeMethod]
         public virtual bool PlayerTextDrawDestroy(int playerid, int text)
         {

--- a/src/SampSharp.GameMode/Display/PlayerTextDraw.cs
+++ b/src/SampSharp.GameMode/Display/PlayerTextDraw.cs
@@ -30,7 +30,7 @@ public partial class PlayerTextDraw : IdentifiedOwnedPool<PlayerTextDraw, BasePl
     public const int InvalidId = 0xFFFF;
 
     /// <summary>Maximum number of player text draws which can exist.</summary>
-    public const int Max = 256;
+    public const int Max = 2048; //2048 adjusted for custom impl of omp server
 
     /// <summary>
     /// Occurs when the <see cref="BaseMode.OnPlayerClickPlayerTextDraw(BasePlayer,ClickPlayerTextDrawEventArgs)" /> is being called. This callback is called

--- a/src/SampSharp.GameMode/Display/TextDraw.Internal.cs
+++ b/src/SampSharp.GameMode/Display/TextDraw.Internal.cs
@@ -29,6 +29,12 @@ public partial class TextDraw
         }
 
         [NativeMethod]
+        public virtual void TextDrawSetPos(int text, float x, float y)
+        {
+            throw new NativeNotImplementedException();
+        }
+
+        [NativeMethod]
         public virtual bool TextDrawDestroy(int text)
         {
             throw new NativeNotImplementedException();

--- a/src/SampSharp.GameMode/Display/TextDraw.cs
+++ b/src/SampSharp.GameMode/Display/TextDraw.cs
@@ -31,7 +31,7 @@ public partial class TextDraw : IdentifiedPool<TextDraw>
     public const int InvalidId = 0xFFFF;
 
     /// <summary>Maximum number of text draws which can exist.</summary>
-    public const int Max = 2048;
+    public const int Max = 256;
 
     /// <summary>
     /// Occurs when the <see cref="BaseMode.OnPlayerClickTextDraw(BasePlayer,ClickTextDrawEventArgs)" /> is being called. This callback is called when a

--- a/src/SampSharp.GameMode/SampSharp.GameMode.csproj
+++ b/src/SampSharp.GameMode/SampSharp.GameMode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Title>SampSharp GameMode Framework</Title>
     <Description>A framework for writing SA-MP game modes in C#.</Description>
   </PropertyGroup>

--- a/src/SampSharp.GameMode/World/BaseVehicle.cs
+++ b/src/SampSharp.GameMode/World/BaseVehicle.cs
@@ -770,7 +770,13 @@ public partial class BaseVehicle : IdentifiedPool<BaseVehicle>, IWorldObject
     {
         AssertNotDisposed();
 
-        VehicleInternal.Instance.SetVehicleParamsCarWindows(Id, (int)driver, (int)passenger, (int)backleft, (int)backright);
+        if (driver != VehicleParameterValue.Unset) driver = (VehicleParameterValue)(driver == VehicleParameterValue.On ? 0 : 1);
+        if (passenger != VehicleParameterValue.Unset) passenger = (VehicleParameterValue)(passenger == VehicleParameterValue.On ? 0 : 1);
+        if (backleft != VehicleParameterValue.Unset) backleft = (VehicleParameterValue)(backleft == VehicleParameterValue.On ? 0 : 1);
+        if (backright != VehicleParameterValue.Unset) backright = (VehicleParameterValue)(backright == VehicleParameterValue.On ? 0 : 1);
+
+
+        VehicleInternal.Instance.SetVehicleParamsCarWindows(Id,(int)driver,(int)passenger,(int)backleft,(int)backright);
     }
 
     /// <summary>Gets the windows parameters.</summary>
@@ -784,8 +790,15 @@ public partial class BaseVehicle : IdentifiedPool<BaseVehicle>, IWorldObject
         AssertNotDisposed();
         VehicleInternal.Instance.GetVehicleParamsCarWindows(Id, out var tmpDriver, out var tmpPassenger, out var tmpBackleft, out var tmpBackright);
 
-        driver = (VehicleParameterValue)tmpDriver;
-        passenger = (VehicleParameterValue)tmpPassenger;
+        if (tmpDriver != -1) tmpDriver = (tmpDriver == 0 ? 1 : 0);
+        if (tmpPassenger != -1) tmpPassenger = (tmpPassenger == 0 ? 1 : 0);
+        if (tmpBackleft != -1) tmpBackleft = (tmpBackleft == 0 ? 1 : 0);
+        if (tmpBackright != -1) tmpBackright = (tmpBackright == 0 ? 1 : 0);
+
+
+
+        driver = (VehicleParameterValue) tmpDriver;
+        passenger = (VehicleParameterValue)tmpPassenger; 
         backleft = (VehicleParameterValue)tmpBackleft;
         backright = (VehicleParameterValue)tmpBackright;
     }

--- a/src/TestMode.Entities/TestMode.Entities.csproj
+++ b/src/TestMode.Entities/TestMode.Entities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/TestMode.GameMode/TestMode.GameMode.csproj
+++ b/src/TestMode.GameMode/TestMode.GameMode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
For some reason, the parameters for Windows are inverted compared to everything else. By default these are the values: -1 (Unset) 0 (Closed/Off) 1 (On / Open)
For vehicle windows, they are: -1 (Unset) 0 (Open) 1(Closed). This behaviour is making VehicleParameterValue enum work not as intended. I've added some checks and inverted them.