### PR TITLE
Fix `'strlen' was not declared in this scope`

### DIFF
--- a/src/SampSharp/locator.cpp
+++ b/src/SampSharp/locator.cpp
@@ -18,6 +18,10 @@
 #include "strutil.h"
 #include <regex>
 
+#ifndef strlen
+#include <cstring>
+#endif
+
 #if SAMPSHARP_WINDOWS
 #define HOSTFXR_LIB "hostfxr.dll"
 #  define CORECLR_LIB "coreclr.dll"


### PR DESCRIPTION
This error happens to me when building the plugin on Void Linux.

```bash
» make --trace  
Makefile:29: update target 'bin/obj/locator.o' due to: src/SampSharp/locator.cpp
mkdir -p bin/obj
echo g++ src/SampSharp/locator.cpp
g++ src/SampSharp/locator.cpp
g++ -O2 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Isrc/SampSharp/includes -Isrc/SampSha
rp/includes/sdk -Isrc/SampSharp/includes/sdk/amx -DNDEBUG -DLINUX -D_GNU_SOURCE -DSAMPGDK_AMALGAMATI
ON -m32 -std=c++17 -m32 -c -o "bin/obj/locator.o" "src/SampSharp/locator.cpp"
src/SampSharp/locator.cpp: In static member function 'static bool locator::detect_lib(std::filesyste
m::__cxx11::path&, const std::string&, const std::string&)':
src/SampSharp/locator.cpp:110:20: error: 'strlen' was not declared in this scope
  110 |         runtime && strlen(runtime) > 0 && detect_lib_recursive(result, fs::path(runtime), li
b) ||
      |                    ^~~~~~
```

I include `cstring.h` just in case it's undefined to make the compiler happy.