### PR TITLE
Fix dialog InvalidOperationException

### DIFF
--- a/src/SampSharp.Entities/SAMP/Dialogs/DialogSystem.cs
+++ b/src/SampSharp.Entities/SAMP/Dialogs/DialogSystem.cs
@@ -24,6 +24,7 @@ public class DialogSystem : ISystem
     {
         player.ResponseReceived = true;
         player.Handler(new DialogResult(DialogResponse.Disconnected, 0, null));
+        player.Destroy();
     }
 
     [Event]


### PR DESCRIPTION
This PR should close #433. I have changed the response handler from `SetResult` to `TrySetResult` to make it safe from the task already completed exception.
However, a better fix might be to not let the response handler executes the second time by destroying the `VisibleDialog` component when the player responds or disconnects. There are two related callbacks: `OnPlayerDisconnect` and `OnPlayerDialogResponse`. But I'm not sure about the execution order of these two callbacks.