### PR TITLE
fix(ecs): Use DateTime.UtcNow.Ticks instead of Stopwatch.GetTimestamp

### DIFF
--- a/src/SampSharp.Entities/Timers/TimerReference.cs
+++ b/src/SampSharp.Entities/Timers/TimerReference.cs
@@ -30,7 +30,7 @@ public class TimerReference
     }
 
     /// <summary>Gets the time span until the next tick of this timer.</summary>
-    public TimeSpan NextTick => new(Info.NextTick - Stopwatch.GetTimestamp());
+    public TimeSpan NextTick => new(Info.NextTick - DateTime.UtcNow.Ticks);
 
     internal TimerInfo Info { get; set; }
 

--- a/src/SampSharp.Entities/Timers/TimerSystem.cs
+++ b/src/SampSharp.Entities/Timers/TimerSystem.cs
@@ -64,7 +64,7 @@ public class TimerSystem : ITickingSystem, ITimerService
         {
             IsActive = true,
             IntervalTicks = interval.Ticks,
-            NextTick = Stopwatch.GetTimestamp() + interval.Ticks
+            NextTick = DateTime.UtcNow.Ticks + interval.Ticks
         };
 
         var reference = new TimerReference(invoker, null, null);
@@ -79,7 +79,7 @@ public class TimerSystem : ITickingSystem, ITimerService
     [Event]
     internal void OnGameModeInit()
     {
-        _lastTick = Stopwatch.GetTimestamp();
+        _lastTick = DateTime.UtcNow.Ticks;
 
         CreateTimersFromAssemblies(_lastTick);
 
@@ -92,7 +92,7 @@ public class TimerSystem : ITickingSystem, ITimerService
         if (!_didInitialize || _timers.Count == 0)
             return;
 
-        var timestamp = Stopwatch.GetTimestamp();
+        var timestamp = DateTime.UtcNow.Ticks;
 
         // Don't user foreach for performance reasons
         // ReSharper disable once ForCanBeConvertedToForeach


### PR DESCRIPTION
**Stopwatch.GetTimestamp** is causing issues on Linux. On this platform, timers run immediately instead of executing at the specified interval. This behavior does not occur on Windows, where the timer works as expected and runs at the correct interval.
