### PR TITLE
feat(ecs): Stop showing a gametext style for all players

### DIFF
--- a/src/SampSharp.Entities/SAMP/Services/IWorldService.cs
+++ b/src/SampSharp.Entities/SAMP/Services/IWorldService.cs
@@ -211,6 +211,15 @@ public interface IWorldService
     /// <param name="style">The style of text to be displayed.</param>
     void GameText(string text, int time, int style);
 
+    /// <summary>
+    /// Stop showing a gametext style for all players.
+    /// </summary>
+    /// <param name="style">The style of text to hide.</param>
+    /// <remarks>
+    /// This function was added in <c>omp v1.1.0.2612</c> and will not work in earlier versions!
+    /// </remarks>
+    void HideGameText(int style);
+
     /// <summary>Creates an explosion for all players.</summary>
     /// <param name="position">The position of the explosion.</param>
     /// <param name="type">The explosion type.</param>

--- a/src/SampSharp.Entities/SAMP/Services/WorldService.cs
+++ b/src/SampSharp.Entities/SAMP/Services/WorldService.cs
@@ -324,6 +324,12 @@ public class WorldService : IWorldService
     }
 
     /// <inheritdoc />
+    public void HideGameText(int style)
+    {
+        _native.HideGameTextForAll(style);
+    }
+
+    /// <inheritdoc />
     public void CreateExplosion(Vector3 position, ExplosionType type, float radius)
     {
         _native.CreateExplosion(position.X, position.Y, position.Z, (int)type, radius);

--- a/src/SampSharp.Entities/SAMP/Services/WorldServiceNative.cs
+++ b/src/SampSharp.Entities/SAMP/Services/WorldServiceNative.cs
@@ -139,6 +139,12 @@ public class WorldServiceNative
     }
 
     [NativeMethod]
+    public virtual void HideGameTextForAll(int style)
+    {
+        throw new NativeNotImplementedException();
+    }
+
+    [NativeMethod]
     public virtual bool CreateExplosion(float x, float y, float z, int type, float radius)
     {
         throw new NativeNotImplementedException();


### PR DESCRIPTION
This PR adds this feature of open.mp: https://www.open.mp/docs/scripting/functions/HideGameTextForAll