### PR TITLE
Merge PR #391 and #393 changes to legacy codebase

### DIFF
--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/CommandsManager.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/CommandsManager.cs
@@ -197,7 +197,7 @@ public class CommandsManager : ICommandsManager
     public ICommand GetCommandForText(BasePlayer player, string commandText)
     {
         ICommand candidate = null;
-        var isFullMath = false;
+        var isFullMatch = false;
         var candidateLength = 0;
 
         foreach (var command in _commands)
@@ -206,9 +206,9 @@ public class CommandsManager : ICommandsManager
             {
                 case CommandCallableResponse.True:
 
-                    if (candidateLength < matchedNameLength || candidateLength == matchedNameLength && !isFullMath)
+                    if (candidateLength < matchedNameLength || candidateLength == matchedNameLength && !isFullMatch)
                     {
-                        isFullMath = true;
+                        isFullMatch = true;
                         candidateLength = matchedNameLength;
                         candidate = command;
                     }

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/DefaultCommand.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/DefaultCommand.cs
@@ -270,7 +270,7 @@ public class DefaultCommand : ICommand
             if (!name.Matches(commandText, IsCaseIgnored)) continue;
 
             matchedNameLength = name.Length;
-            commandText = commandText.Substring(name.Length);
+            commandText = commandText.Substring(name.Length).Trim();
             var result = GetArguments(commandText, out _, out var argumentsLength);
             matchedNameLength += argumentsLength;
             return result

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/EnumType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/EnumType.cs
@@ -45,13 +45,13 @@ public class EnumType<T> : ICommandParameterType where T : struct, IConvertible
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
         output = null;
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
             return false;
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
         var lowerWord = word.ToLower(CultureInfo.InvariantCulture);
 

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/FloatType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/FloatType.cs
@@ -28,13 +28,13 @@ public class FloatType : ICommandParameterType
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
         output = null;
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
             return false;
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
 
         // Unify input culture.

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/IntegerType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/IntegerType.cs
@@ -32,14 +32,14 @@ public class IntegerType : ICommandParameterType
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
         output = null;
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
             return false;
 
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
 
 

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/NullableEnumType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/NullableEnumType.cs
@@ -45,13 +45,13 @@ public class NullableEnumType<T> : ICommandParameterType where T : struct, IConv
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
         output = null;
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
             return false;
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
         var lowerWord = word.ToLower(CultureInfo.InvariantCulture);
 

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/PlayerType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/PlayerType.cs
@@ -29,13 +29,13 @@ public class PlayerType : ICommandParameterType
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
         output = null;
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
             return false;
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
 
         // find a player with a matching id.

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/TextType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/TextType.cs
@@ -25,15 +25,15 @@ public class TextType : ICommandParameterType
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.Trim();
+        commandText = commandText.Trim();
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
         {
             output = null;
             return false;
         }
 
-        output = text;
+        output = commandText;
         commandText = string.Empty;
         return true;
     }

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/VehicleType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/VehicleType.cs
@@ -29,13 +29,13 @@ public class VehicleType : ICommandParameterType
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
         output = null;
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
             return false;
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
 
         // find a vehicle with a matching id.

--- a/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/WordType.cs
+++ b/src/legacy/SampSharp.GameMode/SAMP/Commands/ParameterTypes/WordType.cs
@@ -27,15 +27,15 @@ public class WordType : ICommandParameterType
     /// <returns>true if parsed successfully; false otherwise.</returns>
     public bool Parse(ref string commandText, out object output, bool isNullable = false)
     {
-        var text = commandText.TrimStart();
+        commandText = commandText.TrimStart();
 
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(commandText))
         {
             output = null;
             return false;
         }
 
-        var word = text.Split(' ')
+        var word = commandText.Split(' ')
             .First();
 
         commandText = commandText[word.Length..]

--- a/src/legacy/SampSharp.GameMode/World/BasePlayer.cs
+++ b/src/legacy/SampSharp.GameMode/World/BasePlayer.cs
@@ -79,7 +79,13 @@ public partial class BasePlayer : IdentifiedPool<BasePlayer>, IWorldObject
             PlayerInternal.Instance.GetPlayerName(Id, out var name, MaxNameLength);
             return name;
         }
-        set => PlayerInternal.Instance.SetPlayerName(Id, value);
+        set
+        {
+            if (PlayerInternal.Instance.SetPlayerName(Id, value) == -1)
+            {
+                throw new InvalidOperationException("The name is already in use, too long or has invalid characters.");
+            }
+        }
     }
 
     /// <summary>Gets or sets the facing angle of this Player.</summary>


### PR DESCRIPTION
This PR merges two old PRs into the legacy codebase.

- Fix commands overloading (PR #393):
  - Fix typo isFullMath -> isFullMatch in CommandsManager
  - Trim command text in DefaultCommand and ParameterTypes
  - Refactor ParameterTypes to directly modify commandText parameter
  - Closes #392

- Fix silent fail on player name change (PR #391):
  - Add error checking to SetPlayerName in BasePlayer
  - Throw InvalidOperationException on name change failure
  - Closes #387