### PR TITLE
Get environment from standard environment variable names

### DIFF
--- a/src/SampSharp.OpenMp.Core/LaunchInstructions.cs
+++ b/src/SampSharp.OpenMp.Core/LaunchInstructions.cs
@@ -41,7 +41,10 @@ internal static partial class LaunchInstructions
                                     "commandName": "Executable",
                                     "executablePath": "C:\path\to\server\omp-server.exe",
                                     "workingDirectory": "C:\path\to\server\",
-                                    "commandLineArgs": "-c \"sampsharp.directory=$(TargetDir).\" -c \"sampsharp.assembly=$(TargetName)\""
+                                    "commandLineArgs": "-c \"sampsharp.directory=$(TargetDir).\" -c \"sampsharp.assembly=$(TargetName)\"",
+                                    "environmentVariables": {
+                                      "DOTNET_ENVIRONMENT": "Development"
+                                    }
                                   }
                                 }
                               }
@@ -76,7 +79,10 @@ internal static partial class LaunchInstructions
                         "commandName": "Executable",
                         "executablePath": "{{serverDir}}omp-server.exe",
                         "workingDirectory": "{{serverDir}}",
-                        "commandLineArgs": "-c \"sampsharp.directory=$(TargetDir).\" -c \"sampsharp.assembly=$(TargetName)\""
+                        "commandLineArgs": "-c \"sampsharp.directory=$(TargetDir).\" -c \"sampsharp.assembly=$(TargetName)\"",
+                        "environmentVariables": {
+                          "DOTNET_ENVIRONMENT": "Development"
+                        }
                       }
                     }
                   }
@@ -142,7 +148,7 @@ internal static partial class LaunchInstructions
             }
 
             var exe = Path.Combine(dir, "omp-server.exe");
-
+            
             if (!File.Exists(exe))
             {
                 Console.WriteLine("Invalid directory.");

--- a/src/SampSharp.OpenMp.Entities/Hosting/ConfigurationFactory.cs
+++ b/src/SampSharp.OpenMp.Entities/Hosting/ConfigurationFactory.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace SampSharp.Entities;
+
+internal class ConfigurationFactory
+{
+    public static IConfiguration Create(SampSharpEnvironment environment, Action<IConfigurationBuilder> configure)
+    {
+        var basePath = Path.GetDirectoryName(environment.EntryAssembly.Location) ?? ".";
+
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(basePath)
+            .Add(new OpenMpConfigProvider(environment))
+            .AddEnvironmentVariables()
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{environment.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
+        configure(builder);
+
+        return builder.Build();
+    }
+
+}

--- a/src/SampSharp.OpenMp.Entities/Hosting/EcsHostBuilder.cs
+++ b/src/SampSharp.OpenMp.Entities/Hosting/EcsHostBuilder.cs
@@ -88,9 +88,8 @@ internal sealed class EcsHostBuilder : Extension, IEcsHostBuilder
 
     private IServiceProvider BuildServiceProvider(IStartupContext context)
     {
-        var environment = new SampSharpEnvironment(context.Configurator.GetType().Assembly, context.Core, context.ComponentList, new SafeComponentHandleProvider(context));
-
-        var configuration = CreateConfiguration(environment);
+        var environment = EnvironmentFactory.Create(context);
+        var configuration = ConfigurationFactory.Create(environment, ConfigureAppConfiguration);
 
         var services = new ServiceCollection();
 
@@ -100,6 +99,12 @@ internal sealed class EcsHostBuilder : Extension, IEcsHostBuilder
         services.AddSingleton(configuration);
 
         ConfigureServices(services, configuration, environment);
+
+        if (!_systemsLoadingDisabled)
+        {
+            services.AddSystemsInAssembly(environment.EntryAssembly);
+            _systemsLoadingDisabled = true;
+        }
 
         var factory = _serviceProviderFactory ?? DefaultServiceProviderFactory;
         return factory(services);
@@ -126,29 +131,7 @@ internal sealed class EcsHostBuilder : Extension, IEcsHostBuilder
             .AddSingleton<ITimerService>(s => s.GetRequiredService<TimerSystem>())
             .AddSystem<TimerSystem>()
             .AddSystem<TickingSystem>()
-            .AddSamp()
-            ;
-    }
-
-    private IConfiguration CreateConfiguration(SampSharpEnvironment environment)
-    {
-        var basePath = Path.GetDirectoryName(environment.EntryAssembly.Location) ?? ".";
-        var environmentName = environment.Core.GetConfig().GetString("environment") ?? Environment.GetEnvironmentVariable("environment");
-
-        var builder = new ConfigurationBuilder()
-            .SetBasePath(basePath)
-            .Add(new OpenMpConfigProvider(environment))
-            .AddEnvironmentVariables()
-            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
-
-        if (!string.IsNullOrEmpty(environmentName))
-        {
-            builder.AddJsonFile($"appsettings.{environmentName}.json", optional: true, reloadOnChange: true);
-        }
-
-        ConfigureAppConfiguration(builder);
-
-        return builder.Build();
+            .AddSamp();
     }
 
     private static IServiceProvider DefaultServiceProviderFactory(IServiceCollection services)
@@ -194,12 +177,7 @@ internal sealed class EcsHostBuilder : Extension, IEcsHostBuilder
             configuration(services, config, environment);
         }
 
-        if (!_systemsLoadingDisabled)
-        {
-            services.AddSystemsInAssembly(environment.EntryAssembly);
-            _systemsLoadingDisabled = true;
-        }
-
         _serviceConfigurations.Clear();
     }
+
 }

--- a/src/SampSharp.OpenMp.Entities/Hosting/EnvironmentFactory.cs
+++ b/src/SampSharp.OpenMp.Entities/Hosting/EnvironmentFactory.cs
@@ -1,0 +1,44 @@
+﻿using SampSharp.OpenMp.Core;
+
+namespace SampSharp.Entities;
+
+internal static class EnvironmentFactory
+{
+    public static SampSharpEnvironment Create(IStartupContext context)
+    {
+        var environment = new SampSharpEnvironment(
+            context.Configurator.GetType().Assembly,
+            context.Core,
+            context.ComponentList,
+            new SafeComponentHandleProvider(context),
+            GetEnvironmentName(context));
+        return environment;
+    }
+
+    private static string GetEnvironmentName(IStartupContext context)
+    {
+        var environment = context.Core.GetConfig().GetString("sampsharp.environment");
+
+        if (!string.IsNullOrEmpty(environment))
+        {
+            return environment;
+        }
+
+        environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+
+        if (!string.IsNullOrEmpty(environment))
+        {
+            return environment;
+        }
+
+        environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        if (!string.IsNullOrEmpty(environment))
+        {
+            return environment;
+        }
+
+
+        return "Production";
+    }
+}

--- a/src/SampSharp.OpenMp.Entities/Hosting/Environments.cs
+++ b/src/SampSharp.OpenMp.Entities/Hosting/Environments.cs
@@ -1,0 +1,22 @@
+﻿namespace SampSharp.Entities;
+
+/// <summary>
+/// Defines standard environment names for SampSharp applications. These can be used to differentiate between different deployment environments (e.g., Development, Staging, Production) and enable environment-specific configurations and behaviors.
+/// </summary>
+public static class Environments
+{
+    /// <summary>
+    /// The production environment. This is the default if no environment is specified.
+    /// </summary>
+    public const string Production = "Production";
+
+    /// <summary>
+    /// The development environment. This is used for development and testing purposes. It may enable additional logging and diagnostics.
+    /// </summary>
+    public const string Development = "Development";
+
+    /// <summary>
+    /// The staging environment. This is used for pre-production testing and validation.
+    /// </summary>
+    public const string Staging = "Staging";
+}

--- a/src/SampSharp.OpenMp.Entities/Hosting/SampSharpEnvironment.cs
+++ b/src/SampSharp.OpenMp.Entities/Hosting/SampSharpEnvironment.cs
@@ -14,4 +14,5 @@ namespace SampSharp.Entities;
 /// <param name="Core">The <see cref="ICore" /> interface for the open.mp server. Provides access to core server functionality and extensions.</param>
 /// <param name="Components">The <see cref="IComponentList" /> of open.mp. Manages all game components (players, vehicles, objects, etc.) accessible on the server.</param>
 /// <param name="SafeComponentHandleProvider">A provider of safe handles of open.mp components.</param>
-public record SampSharpEnvironment(Assembly EntryAssembly, ICore Core, IComponentList Components, ISafeComponentHandleProvider SafeComponentHandleProvider);
+/// <param name="EnvironmentName">The name of the environment (e.g., Development, Staging, Production).</param>
+public record SampSharpEnvironment(Assembly EntryAssembly, ICore Core, IComponentList Components, ISafeComponentHandleProvider SafeComponentHandleProvider, string EnvironmentName);

--- a/test/TestMode.OpenMp.Entities/TestMode.OpenMp.Entities.csproj
+++ b/test/TestMode.OpenMp.Entities/TestMode.OpenMp.Entities.csproj
@@ -13,6 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
+      <None Update="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="appsettings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/test/TestMode.OpenMp.Entities/appsettings.Development.json
+++ b/test/TestMode.OpenMp.Entities/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "TestMode": "Debug"
+    },
+    "Omp": {
+      "DebugLevel": "Warning" // log .net debug log messages to the warning channel in open.mp
+    }
+  }
+}


### PR DESCRIPTION
Load environment name from (in this order):
- open.mp config: `sampsharp.environment`
- environment variable: `DOTNET_ENVIRONMENT`
- environment variable: `ASPNETCORE_ENVIRONMENT`

These environment variables are chosen as they match this default behavior: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/environments?view=aspnetcore-10.0#environment-variables-that-determine-the-runtime-environment