### PR TITLE
Fix timer calculations mixing Stopwatch and TimeSpan ticks

### DIFF
--- a/src/SampSharp.OpenMp.Entities/Timers/StopwatchTime.cs
+++ b/src/SampSharp.OpenMp.Entities/Timers/StopwatchTime.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+
+namespace SampSharp.Entities;
+
+internal static class StopwatchTime
+{
+    /// <summary>
+    /// Converts a TimeSpan to Stopwatch ticks.
+    ///
+    /// IMPORTANT:
+    /// - TimeSpan ticks are fixed (1 tick = 100ns, 10,000,000 per second)
+    /// - Stopwatch ticks depend on hardware (Stopwatch.Frequency)
+    ///
+    /// This method converts a TimeSpan duration to the equivalent number
+    /// of Stopwatch ticks so both values can be used in the same time system.
+    /// </summary>
+    public static long ToStopwatchTicks(TimeSpan time)
+    {
+        return (long)(time.TotalSeconds * Stopwatch.Frequency);
+    }
+
+    /// <summary>
+    /// Converts Stopwatch ticks to a TimeSpan.
+    ///
+    /// This is the inverse operation of ToStopwatchTicks.
+    /// It converts a duration measured in Stopwatch ticks back into
+    /// a TimeSpan using Stopwatch.Frequency.
+    /// </summary>
+    public static TimeSpan ToTimeSpan(long stopwatchTicks)
+    {
+        return TimeSpan.FromSeconds(stopwatchTicks / (double)Stopwatch.Frequency);
+    }
+}

--- a/src/SampSharp.OpenMp.Entities/Timers/StopwatchTime.cs
+++ b/src/SampSharp.OpenMp.Entities/Timers/StopwatchTime.cs
@@ -15,9 +15,7 @@ internal static class StopwatchTime
     /// of Stopwatch ticks so both values can be used in the same time system.
     /// </summary>
     public static long ToStopwatchTicks(TimeSpan time)
-    {
-        return (long)(time.TotalSeconds * Stopwatch.Frequency);
-    }
+        => (long)(time.TotalSeconds * Stopwatch.Frequency);
 
     /// <summary>
     /// Converts Stopwatch ticks to a TimeSpan.
@@ -27,7 +25,5 @@ internal static class StopwatchTime
     /// a TimeSpan using Stopwatch.Frequency.
     /// </summary>
     public static TimeSpan ToTimeSpan(long stopwatchTicks)
-    {
-        return TimeSpan.FromSeconds(stopwatchTicks / (double)Stopwatch.Frequency);
-    }
+        => TimeSpan.FromSeconds(stopwatchTicks / (double)Stopwatch.Frequency);
 }

--- a/src/SampSharp.OpenMp.Entities/Timers/TimerReference.cs
+++ b/src/SampSharp.OpenMp.Entities/Timers/TimerReference.cs
@@ -22,9 +22,8 @@ public class TimerReference
     {
         get
         {
-            // Difference between future tick and current time (both in Stopwatch ticks).
-            long delta = Info.NextTick - Stopwatch.GetTimestamp();
-            return StopwatchTime.ToTimeSpan(delta);
+            long remainingStopwatchTicks = Info.NextTick - Stopwatch.GetTimestamp();
+            return StopwatchTime.ToTimeSpan(remainingStopwatchTicks);
         }
     }
 

--- a/src/SampSharp.OpenMp.Entities/Timers/TimerReference.cs
+++ b/src/SampSharp.OpenMp.Entities/Timers/TimerReference.cs
@@ -18,7 +18,15 @@ public class TimerReference
     /// <summary>
     /// Gets the time span until the next tick of this timer.
     /// </summary>
-    public TimeSpan NextTick => new(Info.NextTick - Stopwatch.GetTimestamp());
+    public TimeSpan NextTick
+    {
+        get
+        {
+            // Difference between future tick and current time (both in Stopwatch ticks).
+            long delta = Info.NextTick - Stopwatch.GetTimestamp();
+            return StopwatchTime.ToTimeSpan(delta);
+        }
+    }
 
     internal TimerInfo Info { get; set; }
 

--- a/src/SampSharp.OpenMp.Entities/Timers/TimerSystem.cs
+++ b/src/SampSharp.OpenMp.Entities/Timers/TimerSystem.cs
@@ -99,12 +99,12 @@ internal sealed partial class TimerSystem : ITickingSystem, ITimerService
             throw new ArgumentOutOfRangeException(nameof(interval), interval, "The interval should be a nonzero positive value.");
         }
 
-        long intervalTicks = StopwatchTime.ToStopwatchTicks(interval);
+        long intervalStopwatchTicks = StopwatchTime.ToStopwatchTicks(interval);
         var invoker = new TimerInfo(
-            intervalTicks: intervalTicks, 
+            intervalTicks: intervalStopwatchTicks, 
             // IMPORTANT: 
             // Keeping everything in Stopwatch ticks ensures correct behavior cross-plataform.
-            nextTick: Stopwatch.GetTimestamp() + intervalTicks, 
+            nextTick: Stopwatch.GetTimestamp() + intervalStopwatchTicks, 
             invoke: null!, 
             isActive: true
         );
@@ -167,12 +167,12 @@ internal sealed partial class TimerSystem : ITickingSystem, ITimerService
                 LogLowInterval(target, method.Name, attribute.IntervalTimeSpan);
             }
 
-            long intervalTicks = StopwatchTime.ToStopwatchTicks(attribute.IntervalTimeSpan);
+            long intervalStopwatchTicks = StopwatchTime.ToStopwatchTicks(attribute.IntervalTimeSpan);
             var timer = new TimerInfo(
-                intervalTicks: intervalTicks,
+                intervalTicks: intervalStopwatchTicks,
                 // IMPORTANT: 
                 // Keeping everything in Stopwatch ticks ensures correct behavior cross-plataform.
-                nextTick: tick + intervalTicks, 
+                nextTick: tick + intervalStopwatchTicks, 
                 invoke: () => compiled(service, null, _serviceProvider, null), 
                 isActive: true
             );

--- a/src/SampSharp.OpenMp.Entities/Timers/TimerSystem.cs
+++ b/src/SampSharp.OpenMp.Entities/Timers/TimerSystem.cs
@@ -42,6 +42,8 @@ internal sealed partial class TimerSystem : ITickingSystem, ITimerService
         {
             var timer = _timers[i];
 
+            // IMPORTANT:
+            // Both NextTick and timestamp are in Stopwatch ticks, so the comparison is valid across platforms.
             while (timer.NextTick <= timestamp)
             {
                 try
@@ -97,7 +99,15 @@ internal sealed partial class TimerSystem : ITickingSystem, ITimerService
             throw new ArgumentOutOfRangeException(nameof(interval), interval, "The interval should be a nonzero positive value.");
         }
 
-        var invoker = new TimerInfo(intervalTicks: interval.Ticks, nextTick: Stopwatch.GetTimestamp() + interval.Ticks, invoke: null!, true);
+        long intervalTicks = StopwatchTime.ToStopwatchTicks(interval);
+        var invoker = new TimerInfo(
+            intervalTicks: intervalTicks, 
+            // IMPORTANT: 
+            // Keeping everything in Stopwatch ticks ensures correct behavior cross-plataform.
+            nextTick: Stopwatch.GetTimestamp() + intervalTicks, 
+            invoke: null!, 
+            isActive: true
+        );
 
         var reference = new TimerReference(invoker, action.Target, action.Method);
 
@@ -157,11 +167,15 @@ internal sealed partial class TimerSystem : ITickingSystem, ITimerService
                 LogLowInterval(target, method.Name, attribute.IntervalTimeSpan);
             }
 
+            long intervalTicks = StopwatchTime.ToStopwatchTicks(attribute.IntervalTimeSpan);
             var timer = new TimerInfo(
-                intervalTicks: attribute.IntervalTimeSpan.Ticks, 
-                nextTick: tick + attribute.IntervalTimeSpan.Ticks, 
+                intervalTicks: intervalTicks,
+                // IMPORTANT: 
+                // Keeping everything in Stopwatch ticks ensures correct behavior cross-plataform.
+                nextTick: tick + intervalTicks, 
                 invoke: () => compiled(service, null, _serviceProvider, null), 
-                isActive: true);
+                isActive: true
+            );
 
             timer.Reference = new TimerReference(timer, service, method);
 


### PR DESCRIPTION
## Problem

The timer implementation mixes two different time units:

* `Stopwatch.GetTimestamp()`, which returns timestamps expressed in Stopwatch ticks (`Stopwatch.Frequency` ticks per second).
* `TimeSpan.Ticks`, which uses a fixed resolution of 10,000,000 ticks per second.

These values are currently used interchangeably when scheduling timers.

### Example

```csharp
nextTick = Stopwatch.GetTimestamp() + interval.Ticks;
```

Here `Stopwatch.GetTimestamp()` is expressed in Stopwatch ticks, while `interval.Ticks` is expressed in TimeSpan ticks. These are different units and should not be combined directly.

This issue is less visible on Windows because `Stopwatch.Frequency` commonly matches `TimeSpan.TicksPerSecond` (10,000,000).

On Linux, however, `Stopwatch.Frequency` is typically much higher (for example 1,000,000,000), causing timer intervals to be interpreted incorrectly.

For example:

```text
TimeSpan:
1 second = 10,000,000 ticks

Stopwatch (Linux):
1 second = 1,000,000,000 ticks
```

As a result, a 1-second interval is interpreted as:

```text
10,000,000 / 1,000,000,000 = 0.01 seconds
```

which causes timers to execute approximately 100× faster than expected.

## Solution

Convert `TimeSpan` values to Stopwatch ticks before storing or comparing them:

```csharp
var intervalTicks =
    (long)(interval.TotalSeconds * Stopwatch.Frequency);
```

This ensures that all timer calculations use the same unit (`Stopwatch` ticks) and behave consistently across platforms.
