### PR TITLE
Fix exception handling for multiple Task-based event handlers

### DIFF
--- a/src/SampSharp.OpenMp.Entities/Events/EventDispatcher.cs
+++ b/src/SampSharp.OpenMp.Entities/Events/EventDispatcher.cs
@@ -167,6 +167,11 @@ internal sealed partial class EventDispatcher : IEventDispatcher, IEventService
 
             var targetResult = targetSite.Invoke(targetSite.Target, context);
 
+            if (targetResult is Task task)
+            {
+                HandleTask(task);
+            }
+
             // Do not consider default result as invocation result
             if (targetResult is null || targetResult == defaultResult)
             {

--- a/src/SampSharp.OpenMp.Entities/Events/EventDispatcher.cs
+++ b/src/SampSharp.OpenMp.Entities/Events/EventDispatcher.cs
@@ -62,12 +62,7 @@ internal sealed partial class EventDispatcher : IEventDispatcher, IEventService
             @event.Cache.TryAdd(NullValue.Instance, invoke);
         }
 
-        var result = invoke(arguments);
-
-        if (result is Task task)
-        {
-            HandleTask(task);
-        }
+        invoke(arguments);
     }
 
     [return: NotNullIfNotNull(nameof(defaultValue))]
@@ -103,11 +98,6 @@ internal sealed partial class EventDispatcher : IEventDispatcher, IEventService
         if (result is Task<T> { IsCompleted: true } taskT)
         {
             return taskT.Result;
-        }
-
-        if (result is Task task)
-        {
-            HandleTask(task);
         }
 
         return defaultValue;


### PR DESCRIPTION
## Summary

This PR fixes an issue where exceptions from `Task`-based event handlers could go unobserved when multiple handlers were registered for the same event.

## Problem

`EventDispatcher` only calls `HandleTask` on the final event result returned by `InnerInvoke`.

As a result, when multiple event handlers return a `Task`, only the last task is observed for exceptions. Any faulted tasks returned by previous handlers are silently ignored.

For example:

```csharp
public class SystemA : ISystem
{
    [Event]
    public async Task OnPlayerConnect(Player player)
    {
        throw new Exception("A");
    }
}

public class SystemB : ISystem
{
    [Event]
    public async Task OnPlayerConnect(Player player)
    {
        await Task.Delay(100);
        Console.WriteLine("B");
    }
}
```

Current behavior:

```text
(no exception logged)
```

Expected behavior:

```text
[ERR] Unhandled exception during: async-event
System.Exception: A
```

## Root Cause

`InnerInvoke` iterates through all registered handlers and stores only the last non-null result:

```csharp
foreach (var targetSite in @event.TargetSites)
{
    var targetResult = targetSite.Invoke(...);

    result = targetResult;
}
```

Later, `HandleTask` is only called for the final result:

```csharp
var result = invoke(arguments);

if (result is Task task)
{
    HandleTask(task);
}
```

This means that faulted tasks returned by earlier handlers are never observed.

## Solution

Observe tasks as soon as they are returned by an event handler:

```csharp
if (targetResult is Task task)
{
    HandleTask(task);
}
```

This ensures that every task returned by every event handler is monitored for exceptions, regardless of the final event result.

## Validation

The issue was reproduced using multiple `Task`-based handlers registered for the same event:

```csharp
public class TestSystemA : ISystem
{
    [Event]
    public async Task OnPlayerConnect(Player player)
    {
        await Task.Delay(100);
        throw new Exception("A");
    }
}

public class TestSystemB : ISystem
{
    [Event]
    public async Task OnPlayerConnect(Player player)
    {
        await Task.Delay(200);
        throw new Exception("B");
    }
}

public class TestSystemC : ISystem
{
    [Event]
    public async Task OnPlayerConnect(Player player)
    {
        await Task.Delay(300);
        throw new Exception("C");
    }
}
```

After this change all exceptions are correctly reported:

```text
[ERR] Unhandled exception during: async-event
System.Exception: A

[ERR] Unhandled exception during: async-event
System.Exception: B

[ERR] Unhandled exception during: async-event
System.Exception: C
```
