### PR TITLE
Handle null-callback pool race and Post exceptions in SynchronizationContext

### DIFF
--- a/src/SampSharp.OpenMp.Core/Threading/SendOrPostCallbackItem.cs
+++ b/src/SampSharp.OpenMp.Core/Threading/SendOrPostCallbackItem.cs
@@ -41,11 +41,29 @@ internal sealed class SendOrPostCallbackItem : IDisposable
     {
         try
         {
+            var method = _method;
+
+            // A pooled item must never reach Execute() without a delegate. If it does, it was
+            // Reset() (which nulls _method) between Set() and Execute() — a pool/lifecycle race
+            // that stays rare under light load but surfaces under heavy main-thread marshalling.
+            // Previously this threw a bare NullReferenceException whose only stack frame was this
+            // method, which is impossible to attribute. Surface it explicitly instead, and don't
+            // leave a blocked Send() caller waiting forever or tear down the tick drain.
+            if (method == null)
+            {
+                SampSharpExceptionHandler.HandleException("async",
+                    new InvalidOperationException(
+                        $"{nameof(SendOrPostCallbackItem)}.{nameof(Execute)}: callback was null " +
+                        $"(executionType={_executionType}). Pooled item was reset before execution."));
+                _asyncWaitHandle.Set(); // unblock any waiting Send() caller; no-op for Post
+                return;
+            }
+
             if (_executionType == ExecutionType.Send)
             {
                 try
                 {
-                    _method!(_state);
+                    method(_state);
                 }
                 catch (Exception e)
                 {
@@ -58,7 +76,17 @@ internal sealed class SendOrPostCallbackItem : IDisposable
             }
             else
             {
-                _method!(_state);
+                // Fire-and-forget: nobody observes Exception on a Post item, so a throwing handler
+                // would otherwise escape to the tick-drain catch as an "unhandled" exception with
+                // no context. Capture it here instead.
+                try
+                {
+                    method(_state);
+                }
+                catch (Exception e)
+                {
+                    SampSharpExceptionHandler.HandleException("async post callback", e);
+                }
             }
         }
         finally


### PR DESCRIPTION
## Summary

Hardens `SendOrPostCallbackItem.Execute()` against two failure modes observed
on a production open.mp server under heavy main-thread marshalling:

1. **Null-callback pool race.** A pooled item can reach `Execute()` after
   `Reset()` has nulled `_method` — i.e. the item was recycled by the pool
   before the pump thread finished with it. This is rare under light load but
   reproduces under sustained cross-thread `Send`/`Post` traffic. The old code
   did `_method!(_state)`, so it threw a bare `NullReferenceException` whose
   only stack frame was `Execute()` itself — impossible to attribute to a real
   call site — and a thread blocked in `Send()` would wait on the handle
   **forever** because the `finally` never reached `_asyncWaitHandle.Set()` for
   that path. Now the null case is surfaced explicitly via
   `SampSharpExceptionHandler` and the wait handle is signalled so the caller
   is released.

2. **Swallowed/escaping Post exceptions.** `Post` is fire-and-forget — nobody
   reads `Exception` — so a throwing handler propagated out of `Execute()` into
   the tick-drain `catch` as an "unhandled" exception with no context. It's now
   captured through `SampSharpExceptionHandler` like the `Send` path, just
   without storing it on `Exception` (which no one observes for `Post`).

The change is additive and keeps the existing object pool intact.

## Root cause & a deeper fix (open question)

The guard above makes the race **non-fatal**, but the underlying lifecycle race
between `ObjectPool.Return`/`Reset` and the pump still exists. In our fork we
went further and dropped pooling entirely in `SampSharpSynchronizationContext`
— a fresh single-use `SendOrPostCallbackItem` per call is inherently race-free,
and the allocation is negligible next to the cross-thread hop it represents.

I kept that out of this PR because the pool looks deliberate. Happy to submit
the pool removal as a follow-up if you'd prefer that over the guard — or to
keep the pool and instead fix the `Return`/`Reset` ordering. Your call on the
direction.

## Testing

- `dotnet build SampSharp.slnx` (SampSharp.OpenMp.Core) builds clean (0 errors).
- Verified against the original repro on a live open.mp server: the
  unattributable `NullReferenceException` and the indefinite `Send()` hang no
  longer occur.

No tests added yet — the race is timing-dependent and hard to assert
deterministically; I can add coverage for the null-callback guard path if you'd
like it.