### PR TITLE
feat: make permission denied messages optional and configurable

### DIFF
--- a/src/SampSharp.OpenMp.Entities.Commands/Options/PlayerCommandServiceOptions.cs
+++ b/src/SampSharp.OpenMp.Entities.Commands/Options/PlayerCommandServiceOptions.cs
@@ -10,4 +10,19 @@ public class PlayerCommandServiceOptions : CommandServiceOptions
     /// Defaults to <see cref="Color.White"/>.
     /// </summary>
     public Color UsageMessageColor { get; set; } = Color.White;
+
+    /// <summary>
+    /// Gets or sets the color used when displaying permission denied messages.
+    /// Defaults to <see cref="Color.White"/>.
+    /// </summary>
+    public Color PermissionDeniedMessageColor { get; set; } = Color.White;
+
+    /// <summary>
+    /// Gets or sets the message displayed when a player attempts to execute
+    /// a command without sufficient permissions.
+    /// If <see langword="null"/>, no message is sent.
+    /// Defaults to "You do not have permission to use this command.".
+    /// </summary>
+    public string? PermissionDeniedMessage { get; set; }
+        = "You do not have permission to use this command.";
 }

--- a/src/SampSharp.OpenMp.Entities.Commands/Player/DefaultPlayerCommandMessageService.cs
+++ b/src/SampSharp.OpenMp.Entities.Commands/Player/DefaultPlayerCommandMessageService.cs
@@ -94,8 +94,10 @@ public class DefaultPlayerCommandMessageService : IPlayerCommandMessageService
         ArgumentNullException.ThrowIfNull(player);
         ArgumentNullException.ThrowIfNull(overload);
 
-        const string message = "You do not have permission to use this command.";
-        player.SendClientMessage(message);
+        if (_options.PermissionDeniedMessage is null)
+            return true;
+
+        player.SendClientMessage(_options.PermissionDeniedMessageColor, _options.PermissionDeniedMessage);
         return true;
     }
 


### PR DESCRIPTION
## Summary

This PR makes permission denied messages configurable in `PlayerCommandServiceOptions`.

### Changes

- Added `PermissionDeniedMessageColor`.
- Added `PermissionDeniedMessage`.
- Allow disabling permission denied messages by setting `PermissionDeniedMessage` to `null`.

### Motivation

Previously, permission denied responses were hardcoded inside the command service.

This change allows servers to:

- Customize the message text.
- Customize the message color.
- Disable the default message entirely and handle permission feedback through other mechanisms (e.g. GameText and sounds).