### PR TITLE
feat: add CommandDefinition.GetTag helper

### DIFF
--- a/src/SampSharp.OpenMp.Entities.Commands/Core/CommandDefinition.cs
+++ b/src/SampSharp.OpenMp.Entities.Commands/Core/CommandDefinition.cs
@@ -88,4 +88,16 @@ public class CommandDefinition
 
     /// <summary>Custom metadata tags attached to this overload.</summary>
     public IReadOnlyDictionary<string, string> Tags => _tags;
+
+    /// <summary>
+    /// Gets the value of the specified command tag, or <see langword="null"/>
+    /// if the tag is not present.
+    /// </summary>
+    public string? GetTag(string key)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        return _tags.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
 }


### PR DESCRIPTION
The documentation includes a sample example:
```cs
public class MyPermissionChecker : IPermissionChecker
{
    public bool HasPermission(Player player, CommandDefinition command)
    {
        var permission = command.GetTag("permission");
        if (permission == null)
            return true; // No permission requirement
        
        return player.HasPermission(permission);
    }
}
```
But the `GetTag` method doesn't exist in `CommandDefinition`. This PR adds that helper.