### PR TITLE
docs: add Projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Examples
 --------
 Example gamemodes and sample projects are available at [https://github.com/sampsharp/samples](https://github.com/sampsharp/samples)
 
+Projects
+--------
+Real projects built with SampSharp:
+
+- [Capture the Flag](https://github.com/DevD4v3/Capture-The-Flag)
+- [Open Roleplay](https://github.com/OpenRoleplay/OpenRP.Framework)
+
 Building for Developers
 -----------------------
 


### PR DESCRIPTION
The README currently links to examples and sample projects, but does not highlight real projects built with SampSharp.

This adds a Projects section to showcase projects using SampSharp while keeping it separate from the Examples section, which is intended for learning and reference.